### PR TITLE
Clarify Message Body AAD Content Length field for framed data

### DIFF
--- a/client-apis/encrypt.md
+++ b/client-apis/encrypt.md
@@ -55,7 +55,7 @@ A Keyring that implements the [keyring interface](#keyring-interface.md).
 
 ### Frame Length
 
-The length of the frame to use for [framed data](#message-body.md).
+The [frame length](#message-header.md#frame-length) to use for [framed data](#message-body.md).
 This value MUST NOT exceed the value 2^32 - 1.
 
 ### Plaintext Length

--- a/data-format/message-body-aad.md
+++ b/data-format/message-body-aad.md
@@ -62,8 +62,9 @@ More specifically, depending on the [content type](message-header.md#content-typ
   of the plaintext being encrypted in this frame.
   - For [regular frames](message-body.md#regular-frame), this value MUST equal the value of
     the [frame length](message-hedaer.md#frame-length) field in the message header.
-  - For the [final frame](message-body.md#final-frame), this value MUST be equal to or less than
-    the value of the [frame length](message-hedaer.md#frame-length) field in the message header.
+  - For the [final frame](message-body.md#final-frame), this value MUST be greater than or equal to
+    0 and less than or equal to the value of the [frame length](message-hedaer.md#frame-length)
+    field in the message header.
 
 ## Security Considerations
 

--- a/data-format/message-body-aad.md
+++ b/data-format/message-body-aad.md
@@ -52,12 +52,18 @@ For [non-framed data](#message-body.md#framed-data), the value of this field MUS
 
 ### Content Length
 
-This value depends on the [content type](message-header.md#content-type) of the [message](message.md):
+The length, in bytes, of the plaintext data being encrypted that this message body AAD is associated with.
+
+More specifically, depending on the [content type](message-header.md#content-type) of the [message](message.md):
 
 - For [non-framed data](message-body.md#non-framed-data), this value MUST equal the length, in bytes,
   of the plaintext data provided to the algorithm for encryption.
 - For [framed data](message-body.md#framed-data), this value MUST equal the length, in bytes,
-  of the frame being encrypted.
+  of the plaintext being encrypted in this frame.
+  - For [regular frames](message-body.md#regular-frame), this value MUST equal the value of
+    the [frame length](message-hedaer.md#frame-length) field in the message header.
+  - For the [final frame](message-body.md#final-frame), this value MUST be equal to or less than
+    the value of the [frame length](message-hedaer.md#frame-length) field in the message header.
 
 ## Security Considerations
 

--- a/data-format/message-body-aad.md
+++ b/data-format/message-body-aad.md
@@ -52,7 +52,12 @@ For [non-framed data](#message-body.md#framed-data), the value of this field MUS
 
 ### Content Length
 
-The length, in bytes, of the plaintext data provided to the algorithm for encryption.
+This value depends on the [content type](message-header.md#content-type) of the [message](message.md):
+
+- For [non-framed data](message-body.md#non-framed-data), this value MUST equal the length, in bytes,
+  of the plaintext data provided to the algorithm for encryption.
+- For [framed data](message-body.md#framed-data), this value MUST equal the length, in bytes,
+  of the frame being encrypted.
 
 ## Security Considerations
 

--- a/data-format/message-body.md
+++ b/data-format/message-body.md
@@ -128,7 +128,7 @@ specified by the [Algorithm Suite ID](#message-header.md#algorithm-suite-id) fie
 
 The last frame in a framed body MUST be a Final Frame.  
 
-The length of the Final Frame MUST be less than or equal to the [Frame Length](#message-header.md#frame-length).
+The length of the plaintext to be encrypted in the Final Frame MUST be less than or equal to the [Frame Length](#message-header.md#frame-length).
 
 - When the length of the Plaintext is not an exact multiple of the Frame Length, any remaining data is encrypted into the Final Frame.  
 - When the length of the Plaintext is an exact multiple of the Frame Length, the Final Frame encrypted content length SHOULD be equal to the frame length but MAY be 0.  

--- a/data-format/message-body.md
+++ b/data-format/message-body.md
@@ -128,7 +128,8 @@ specified by the [Algorithm Suite ID](#message-header.md#algorithm-suite-id) fie
 
 The last frame in a framed body MUST be a Final Frame.  
 
-The length of the plaintext to be encrypted in the Final Frame MUST be less than or equal to the [Frame Length](#message-header.md#frame-length).
+The length of the plaintext to be encrypted in the Final Frame MUST be
+greater than or equal to 0 and less than or equal to the [Frame Length](#message-header.md#frame-length).
 
 - When the length of the Plaintext is not an exact multiple of the Frame Length, any remaining data is encrypted into the Final Frame.  
 - When the length of the Plaintext is an exact multiple of the Frame Length, the Final Frame encrypted content length SHOULD be equal to the frame length but MAY be 0.  


### PR DESCRIPTION
*Issue #, if available:* closes #38 

*Description of changes:* Updates ContentLength to specify correct behavior in case framed data is being used.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
