### PR TITLE
Remove lines mandating region be specified by KMS keyring generator

### DIFF
--- a/framework/kms-keyring.md
+++ b/framework/kms-keyring.md
@@ -209,7 +209,7 @@ as described above, OnEncrypt MUST also attempt to encrypt the plaintext data ke
 
 To attempt to encrypt the plaintext data key with a particular CMK, OnEncrypt MUST call [KMS Encrypt](#kms-encrypt).
 
-For each [KMS Encrypt](#kms-encrypt) call, if an AWS region can be extracted from the CMK ARN, then the
+For each [KMS Encrypt](#kms-encrypt) call, if an AWS region can be extracted from the [Key Id](#key-ids), then the
 [KMS client](#kms-client) that calls [KMS Encrypt](#kms-encrypt) MUST be the client returned by the
 [client supplier](#client-supplier) when given that region as input.
 If an AWS region cannot be extracted from the CMK ARN then the KMS Keyring MUST input a value denoting an unknown region.

--- a/framework/kms-keyring.md
+++ b/framework/kms-keyring.md
@@ -160,9 +160,9 @@ If the input [encryption materials](#structures.md#encryption-materials) do not 
 and this keyring has a [generator](#generator) defined, and onEncrypt MUST attempt to generate a new plaintext data key
 and encrypt that data key by calling [KMS GenerateDataKey](#kms-generatedatakey).
 
-The [KMS client](#kms-client) that calls [KMS GenerateDataKey](#kms-generatedatakey) MUST be the
-client returned by the [client supplier](#client-supplier).
-The client MUST be a client that calls the AWS region specified in the [generator](#generator) ARN.
+If an AWS region can be extracted from the [generator](#generator), then the [KMS client](#kms-client) that calls
+[KMS GenerateDataKey](#kms-generatedatakey) MUST be the client returned by the [client supplier](#client-supplier)
+when given that region as input.
 If the [client supplier](#client-supplier) does not provide any client for the given region for this GenerateDataKey call,
 OnEncrypt MUST fail.
 
@@ -266,9 +266,10 @@ in the input encrypted data key list with the following conditions, until it suc
 To attempt to decrypt a particular [encrypted data key](#structures.md#encrypted-data-key),
 OnDecrypt MUST call [KMS Decrypt](#kms-decrypt).
 
-The [KMS client](#kms-client) that calls [KMS Decrypt](#kms-decrypt) MUST be the
-client returned by the [client supplier](#client-supplier).
-The client MUST be a client that calls the AWS region specified in the [generator](#generator) ARN.
+
+If an AWS region can be extracted from the [generator](#generator), then the [KMS client](#kms-client) that calls
+[KMS Decrypt](#kms-decrypt) MUST be the client returned by the [client supplier](#client-supplier)
+when given that region as input.
 If the [client supplier](#client-supplier) does not provide any client for the given region for the Decrypt call,
 OnDecrypt MUST skip that particular [encrypted data key](#encrypted-data-key).
 

--- a/framework/kms-keyring.md
+++ b/framework/kms-keyring.md
@@ -271,7 +271,6 @@ OnDecrypt MUST call [KMS Decrypt](#kms-decrypt).
 For each [KMS Decrypt](#kms-decrypt) call, if an AWS region can be extracted from the [encrypted data key](structures.md#encrypted-data-key)'s [key provider info](structures.md#key-provider-information).
 The KMS Keyring MUST call [KMS Decrypt](#kms-decrypt) using the client supplied by the [client supplier](#client-supplier), given the region as input.
 
-If an AWS region cannot be extracted from the [encrypted data key](structures.md#encrypted-data-key)'s [key provider info](structures.md#key-provider-information) then the KMS Keyring MUST input to the [client supplier](#client-supplier) a value denoting an unknown region.
 If the client supplier does not provide any client for the given region for this Decrypt call, OnDecrypt MUST skip that particular [encrypted data key](#encrypted-data-key).
 
 When calling [KMS Decrypt](#kms-decrypt), the keyring MUST call with a request constructed as follows:

--- a/framework/kms-keyring.md
+++ b/framework/kms-keyring.md
@@ -268,7 +268,7 @@ in the input encrypted data key list with the following conditions, until it suc
 To attempt to decrypt a particular [encrypted data key](#structures.md#encrypted-data-key),
 OnDecrypt MUST call [KMS Decrypt](#kms-decrypt).
 
-For each [KMS Decrypt](#kms-decrypt) call, if an AWS region can be extracted from the [encrypted data key](structures.md#encrypted-data-key)'s [key provider info](structures.md#key-provider-information).
+For each [KMS Decrypt](#kms-decrypt) call, an AWS region MUST be extracted from the [encrypted data key](structures.md#encrypted-data-key)'s [key provider info](structures.md#key-provider-information).
 The KMS Keyring MUST call [KMS Decrypt](#kms-decrypt) using the client supplied by the [client supplier](#client-supplier), given the region as input.
 
 If the client supplier does not provide any client for the given region for this Decrypt call, OnDecrypt MUST skip that particular [encrypted data key](#encrypted-data-key).

--- a/framework/kms-keyring.md
+++ b/framework/kms-keyring.md
@@ -194,8 +194,8 @@ If verified, OnEncrypt MUST do the following with the response from [KMS Generat
   - the [key provider information](#data-strucures.md#key-provider-information) is the response `KeyId`.
 - append a new [record](#structures.md#record) to the [keyring trace](#structures.md#keyring-trace)
   in the input [encryption materials](#structures.md#encryption-materials), constructed as follows:
-  - The string field KeyNamespace contains "aws-kms".
-  - The string field KeyName contains the value of the KMS Keyring's [generator](#generator) field.
+  - The string field KeyNamespace is "aws-kms".
+  - The string field KeyName is the value of the KMS Keyring's [generator](#generator) field.
   - The [flags](#structures.md$flags) field of this record includes exactly the following flags:
     - [GENERATED DATA KEY](#structures.md#supported-flags)
     - [ENCRYPTED DATA KEY](#structures.md#supported-flags)
@@ -299,8 +299,8 @@ If the response is successfully verified, OnDecrypt MUST do the following with t
 - set the plaintext data key on the [decryption materials](#structures.md#decryption-materials) as the response `Plaintext`.
 - append a new [record](#structures.md#record) to the [keyring trace](#structures.md#keyring-trace)
   in the input [encryption materials](#structures.md#encryption-materials), constructed as follows:
-  - The string field KeyNamespace contains "aws-kms".
-  - The string field KeyName contains the [encrypted data key's key provider info](structures.md#key-provider-information).
+  - The string field KeyNamespace is "aws-kms".
+  - The string field KeyName is the [encrypted data key's key provider info](structures.md#key-provider-information).
   - The [flags](#structures.md$flags) field of this record includes exactly the following flags:
     - [DECRYPTED DATA KEY](#structures.md#supported-flags)
     - [VERIFIED ENCRYPTION CONTEXT](#structures.md#supported-flags)

--- a/framework/kms-keyring.md
+++ b/framework/kms-keyring.md
@@ -211,7 +211,7 @@ To attempt to encrypt the plaintext data key with a particular CMK, OnEncrypt MU
 For each [KMS Encrypt](#kms-encrypt) call, if an AWS region can be extracted from the [Key ID](#key-ids), then the
 [KMS client](#kms-client) that calls [KMS Encrypt](#kms-encrypt) MUST be the client returned by the
 [client supplier](#client-supplier) when given that region as input.
-If an AWS region cannot be extracted from the CMK ARN then the KMS Keyring MUST input a value denoting an unknown region.
+If an AWS region cannot be extracted from the Key ID then the KMS Keyring MUST input a value denoting an unknown region.
 If the [client supplier](#client-supplier) does not provide any client for the given region for this Encrypt call, OnEncrypt MUST skip that particular CMK.
 
 To encrypt the plaintext data key with a CMK, OnEncrypt MUST call [KMS Encrypt](#encrypt) with a request

--- a/framework/kms-keyring.md
+++ b/framework/kms-keyring.md
@@ -236,8 +236,8 @@ If the call succeeds, OnEncrypt MUST do the following with the response from [KM
     Note that the `KeyId` in the response is always in key ARN format.
 - append a new [record](#structures.md#record) to the [keyring trace](#structures.md#keyring-trace)
   in the input [encryption materials](#structures.md#encryption-materials), constructed as follows:
-  - The string field KeyNamespace contains "aws-kms".
-  - The string field KeyName contains the CMK ARN used for [KMS Encrypt](#kms-encrypt).
+  - The string field KeyNamespace is "aws-kms".
+  - The string field KeyName is the response `KeyId`. Note that the `KeyId` in the response is always in key ARN format.
   - The [flags](#structures.md$flags) field of this record includes exactly the following flags:
     - [ENCRYPTED DATA KEY](#structures.md#supported-flags)
     - [SIGNED ENCRYPTION CONTEXT](#structures.md#supported-flags)

--- a/framework/kms-keyring.md
+++ b/framework/kms-keyring.md
@@ -165,7 +165,7 @@ If an AWS region can be extracted from the [generator](#generator), then the [KM
 [KMS GenerateDataKey](#kms-generatedatakey) MUST be the client returned by the [client supplier](#client-supplier)
 when given that region as input.
 If an AWS region cannot be extracted from the [generator](#generator) then the KMS Keyring MUST input a value denoting an unknown region.
-If the [client supplier](#client-supplier) does not provide any client for the given region for this [KMS GenerateDataKey](#kms-generatedatakey) call, OnEncrypt MUST not modify the [encryption materials](#structures.md#encryption-materials.md)
+If the [client supplier](#client-supplier) does not provide any client for the given region for this [KMS GenerateDataKey](#kms-generatedatakey) call, OnEncrypt MUST NOT modify the [encryption materials](#structures.md#encryption-materials.md)
 and MUST fail.
 
 When calling [KMS GenerateDataKey](#kms-generatedatakey), the keyring MUST call with a request constructed as follows:

--- a/framework/kms-keyring.md
+++ b/framework/kms-keyring.md
@@ -208,7 +208,7 @@ as described above, OnEncrypt MUST also attempt to encrypt the plaintext data ke
 
 To attempt to encrypt the plaintext data key with a particular CMK, OnEncrypt MUST call [KMS Encrypt](#kms-encrypt).
 
-For each [KMS Encrypt](#kms-encrypt) call, if an AWS region can be extracted from the [Key Id](#key-ids), then the
+For each [KMS Encrypt](#kms-encrypt) call, if an AWS region can be extracted from the [Key ID](#key-ids), then the
 [KMS client](#kms-client) that calls [KMS Encrypt](#kms-encrypt) MUST be the client returned by the
 [client supplier](#client-supplier) when given that region as input.
 If an AWS region cannot be extracted from the CMK ARN then the KMS Keyring MUST input a value denoting an unknown region.

--- a/framework/kms-keyring.md
+++ b/framework/kms-keyring.md
@@ -81,7 +81,7 @@ Each Key ID MUST be one of the following:
 
 - A CMK [alias](https://docs.aws.amazon.com/kms/latest/developerguide/programming-aliases.html) (e.g. "alias/MyCryptoKey")
 - A well-formed key ARN (e.g. arn:aws:kms:us-east-1:999999999999:key/01234567-89ab-cdef-fedc-ba9876543210)
-- A well-formned alias ARN (e.g. arn:aws:kms:us-east-1:999999999999:alias/MyCryptoKey)
+- A well-formed alias ARN (e.g. arn:aws:kms:us-east-1:999999999999:alias/MyCryptoKey)
 
 See [AWS Documentation](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-kms).
 
@@ -102,7 +102,7 @@ The string MUST be one of the following:
 
 - A CMK [alias](https://docs.aws.amazon.com/kms/latest/developerguide/programming-aliases.html) (e.g. "alias/MyCryptoKey")
 - A well-formed key ARN (e.g. arn:aws:kms:us-east-1:999999999999:key/01234567-89ab-cdef-fedc-ba9876543210)
-- A well-formned alias ARN (e.g. arn:aws:kms:us-east-1:999999999999:alias/MyCryptoKey)
+- A well-formed alias ARN (e.g. arn:aws:kms:us-east-1:999999999999:alias/MyCryptoKey)
 
 See [AWS Documentation](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-kms).
 
@@ -207,9 +207,9 @@ as described above, OnEncrypt MUST also attempt to encrypt the plaintext data ke
 
 To attempt to encrypt the plaintext data key with a particular CMK, OnEncrypt MUST call [KMS Encrypt](#kms-encrypt).
 
-The [KMS client](#kms-client) that calls [KMS Encrypt](#kms-encrypt) MUST be the
-client returned by the [client supplier](#client-supplier).
-The client MUST be a client that calls the AWS region specified in the [generator](#generator) ARN.
+If an AWS region can be extracted from the [generator](#generator), then the [KMS client](#kms-client) that calls
+[KMS Encrypt](#kms-encrypt) MUST be the client returned by the [client supplier](#client-supplier)
+when given that region as input.
 If the [client supplier](#client-supplier) does not provide any client for the given region for this Encrypt call,
 OnEncrypt MUST skip that particular CMK.
 

--- a/framework/kms-keyring.md
+++ b/framework/kms-keyring.md
@@ -65,7 +65,7 @@ On keyring initialization, a keyring MAY define the following:
 ### Client Supplier
 
 A function which MUST take as input either a region string (e.g. `us-east-1`), or some value denoting an unknown region,
-and MAY return a KMS Client which can make the following API calls in the given AWS region:
+and MAY return a KMS Client that can make the following API calls in the given AWS region:
 
 - [GenerateDataKey](#kms-generatedatakey)
 - [Encrypt](#kms-encrypt)

--- a/framework/kms-keyring.md
+++ b/framework/kms-keyring.md
@@ -200,7 +200,6 @@ If verified, OnEncrypt MUST do the following with the response from [KMS Generat
     - [GENERATED DATA KEY](#structures.md#supported-flags)
     - [ENCRYPTED DATA KEY](#structures.md#supported-flags)
     - [SIGNED ENCRYPTION CONTEXT](#structures.md#supported-flags)
-    
 Given a plaintext data key in the [encryption materials](#structures.md#encryption-materials),
 OnEncrypt MUST attempt to encrypt the plaintext data key using each CMK specified in it's [key IDs](#key-ids) list.
 

--- a/framework/kms-keyring.md
+++ b/framework/kms-keyring.md
@@ -64,7 +64,7 @@ On keyring initialization, a keyring MAY define the following:
 
 ### Client Supplier
 
-A function which MUST take as input either a region string (e.g. `us-east-1`), or some value denoting an unknown region,
+A function that MUST take as input either a region string (e.g. `us-east-1`), or some value denoting an unknown region,
 and MAY return a KMS Client that can make the following API calls in the given AWS region:
 
 - [GenerateDataKey](#kms-generatedatakey)


### PR DESCRIPTION
*Issue #, if available:* #49 

*Description of changes:* Changes to OnEncrypt/OnDecrypt to relax the dependence on generator ARN for AWS region.

*What this PR does NOT cover:* This PR does NOT redefine the Client Supplier to take a CMK ARN as input.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
