### PR TITLE
Rewrite Keyring interfaces in functional style

### DIFF
--- a/framework/cmm-interface.md
+++ b/framework/cmm-interface.md
@@ -85,17 +85,10 @@ it MUST return [encryption materials](#structures.md#encryption-materials) appro
 
 The encryption materials returned MUST include the following:
 
-- [Algorithm Suite](#algorithm-suite.md)
-    - If the encryption materials request contains an algorithm suite, the encryption materials returned SHOULD contain the same algorithm suite.
-- Plaintext Data Key
-- [Encrypted Data Keys](#structures.md#encrypted-data-keys)
-    - Every encrypted data key in this list MUST correspond to the above plaintext data key. 
+- [Data Key Materials](#structures.md#data-key-materials.md)
+    - If the encryption materials request contains an algorithm suite, the data key materials returned SHOULD contain the same algorithm suite.
 - [Encryption Context](#structures.md#encryption-context)
-    - The CMM MAY modify the encryption context.   
-
-The encryption materials returned MAY include the following:
-
-- [Keyring Trace](#structures.md#keyring-trace)
+    - The CMM MAY return an encryption context that differs from the input.   
 
 If the algorithm suite contains a [signing algorithm](#algorithm-suites.md#signature-algorithm): 
 

--- a/framework/default-cmm.md
+++ b/framework/default-cmm.md
@@ -33,7 +33,7 @@ in this document are to be interpreted as described in [RFC 2119](https://tools.
 
 - If the encryption materials request does not contain an algorithm suite, 
 the algorithm suite with algorithm suite ID [03 78 (hex)](algorithm-suites.md#supported-algorithm-suites) 
-MUST be added as the algorithm suite in the encryption materials returned.  
+MUST be referenced as the algorithm suite in the encryption materials returned.  
 - If the encryption materials request does contain an algorithm suite, the encryption materials returned MUST contain the same algorithm suite.
 
 If the algorithm suite contains a [signing algorithm](#algorithm-suites.md#signature-algorithm), the default CMM MUST:

--- a/framework/keyring-interface.md
+++ b/framework/keyring-interface.md
@@ -43,9 +43,10 @@ The following inputs are REQUIRED:
 
 The following inputs are OPTIONAL:
 
-- [Plaintest Data Key](#structures.md#plaintext-data-key)
+- [Plaintext Data Key](#structures.md#plaintext-data-key)
 
-This interface MAY return [data key materials](#structures.md#data-key-materials) appropriate for the request. 
+This interface MAY return [data key materials](#structures.md#data-key-materials) appropriate for the request. If it does return this output
+and a plaintext data key was provided as input, the output must specify the same plaintext data key.
 
 The output of this interface is driven by two behaviours:
 
@@ -122,7 +123,8 @@ This interface MAY perform the following behavior:
 
 - [Decrypt data key](#decrypt-data-key)
 
-If this keyring attempted the above behavior, and succeeded, it MUST output the resulting [data key materials](#structures.md#data-key-materials). The [algorithm suite](#algorithm-suites.md) in the result must match the input [algorithm suite](#algorithm-suites.md).
+If this keyring attempted the above behavior, and succeeded, it MUST output the resulting [data key materials](#structures.md#data-key-materials). The [algorithm suite](#algorithm-suites.md) in the result must match the input [algorithm suite](#algorithm-suites.md), and the [encrypted data keys](#structures.md#encrypted-data-keys)
+list must be empty.
 
 If the keyring did not attempt the above behavior, it MUST produce no output.
 

--- a/framework/kms-keyring.md
+++ b/framework/kms-keyring.md
@@ -293,7 +293,7 @@ If the call to [KMS Decrypt](#kms-decrypt) succeeds OnDecrypt MUST verify the fo
 - verify that the `KeyId` field has a value equal to the [encrypted data key's key provider info](##structures.md#key-provider-info).
 - verify that the `Plaintext` is of a length that fits the [algorithm suite](#algorithm-suites.md) given in the decryption materials.
 
-If any of the above are not true, OnDecrpyt MUST fail.
+If any of the above are not true, OnDecrypt MUST fail.
 
 If the response is successfully verified, OnDecrypt MUST do the following with the response:
 

--- a/framework/raw-rsa-keyring.md
+++ b/framework/raw-rsa-keyring.md
@@ -93,26 +93,25 @@ OnEncrypt MUST NOT succeed if this keyring does not have a specified [public key
 
 OnEncrypt MUST take [encryption materials](#structures.md#encryption-materials) as input.
 
-If the [encryption materials](#structures.md#encryption-materials) do not contain a plaintext data key,
-on encrypt MUST generate a random plaintext data key and set it on the [encryption materials](#structures.md#encryption-materials).
+If the input does not contain a plaintext data key, OnEncrypt MUST generate a random plaintext data key.
 
-The keyring MUST attempt to encrypt the plaintext data key in the
-[encryption materials](#structures.md#encryption-materials) using RSA.
+The keyring MUST attempt to encrypt the plaintext data key using RSA.
+
 The keyring performs RSA with the following specifics:
 
 - this keyring's [public key](#public-key) is the RSA public key
 - this keyring's [padding scheme](padding-scheme) is the RSA padding scheme.
 - the plaintext data key is the plaintext input to RSA encryption.
 
-If RSA encryption was successful, OnEncrypt MUST return the input
-[encryption materials](#structures.md#encryption-materials), modified in the following ways:
+If RSA encryption was successful, OnEncrypt MUST return
+[data key materials](#structures.md#encryption-materials), specified in the following ways:
 
-- The encrypted data key list has a new encrypted data key added, constructed as follows:
+- The encrypted data key list contains a single encrypted data key, constructed as follows:
   - the [key provider ID](#structures.md#key-provider-id) field is this keyring's [key namespace](#key-id).
   - the [key provider information](#structures.md#key-provider-information) field is this keyring's [key name](#key-name).
   - the [ciphertext](#structures.md#data-key-encryption) field is the ciphertext outputted from
     the RSA encryption of the plaintext data key.
-- The keyring trace has a new [record](#structures.md#record) appended.
+- The keyring trace has a single [record](#structures.md#record).
   This record MUST contain this keyring's [key name](#key-name) and [key namespace](#key-namespace),
   and the [flags](#structures.md$flags) field of this record MUST include the
   [ENCRYPTED DATA KEY](#structures.md#supported-flags) flag.
@@ -125,8 +124,11 @@ If RSA encryption was successful, OnEncrypt MUST return the input
 OnDecrypt MUST NOT succeed if this keyring does not have a specified [private key](#private-key).
 The keyring MUST NOT derive a private key from a specified [public key](#public-key)
 
-OnDecrypt MUST take [decryption materials](#structures.md#decryption-materials) and
-a list of [encrypted data keys](#structures.md#encrypted-data-key) as input.
+The following inputs are REQUIRED:
+
+- [Algorithm Suite](#algorithm-suites.md)
+- [Encryption Context](#structures.md#encryption-context)
+- [Encrypted Data Keys](#structures.md#encrypted-data-keys)
 
 The keyring MUST attempt to decrypt the inputted encrypted data keys, in list order, until it successfully decrypts one.
 
@@ -144,17 +146,17 @@ The keyring performs RSA decryption with the following specifics:
 - this keyring's [padding scheme](padding-scheme) is the RSA padding scheme.
 - an encrypted data key's [ciphertext](#structures.md#ciphertext) is the input ciphertext to RSA decryption.
 
-If any decryption succeeds, this keyring MUST immediately return the input
-[decryption materials](#structures.md#decryption-materials), modified in the following ways:
+If any decryption succeeds, this keyring MUST immediately return
+[data key materials](#structures.md#data-key-materials), specified in the following ways:
 
-- The output of RSA decryption is set as the decryption material's plaintext data key.
-- The keyring trace has a new [record](#structures.md#record) appended.
+- The output of RSA decryption is set as the data key materials' plaintext data key.
+- The keyring trace has a single [record](#structures.md#record).
   This record MUST contain this keyring's [key name](#key-name) and [key namespace](#key-namespace),
   and the [flags](#structures.md$flags) field of this record MUST include the
   [DECRYPTED DATA KEY](#structures.md#supported-flags) flag.
   The record MUST NOT contain the [VERIFIED ENCRYPTION CONTEXT flag](#structures.md#flags).
 
-If no decryption succeeds, this keyring MUST NOT make any update to the decryption materials.
+If no decryption succeeds, this keyring MUST produce no output.
 
 ## Security Considerations
 

--- a/framework/structures.md
+++ b/framework/structures.md
@@ -26,6 +26,10 @@ Note that this specification does not specify how these structures should be rep
 throughout the AWS Encryption SDK framework.
 While these structures will usually be represented as objects, lower level languages MAY represent
 these fields in a less strictly defined way as long as all field properties are still upheld.
+In addition, this specification describes interfaces as if they accepted immutable values as input and
+produced new immutable values as output. Some languages may implement the interfaces by storing results
+into pre-allocated locations that are passed by reference, or even using a mutable structure as both input and
+output.
 
 Structures defined in this document:
 
@@ -118,48 +122,15 @@ The encryption context MUST reserve the following key fields for use by the AWS 
 The encryption context SHOULD reserve any key field with the prefix `aws` for use by AWS KMS and
 other AWS services.
 
-### Encryption Materials
+### Data Key Materials
 
 #### Implementations
 
-- [Java](https://github.com/aws/aws-encryption-sdk-java/blob/master/src/main/java/com/amazonaws/encryptionsdk/model/EncryptionMaterials.java)
-- [Python](https://github.com/aws/aws-encryption-sdk-python/blob/master/src/aws_encryption_sdk/materials_managers/__init__.py)
-- [C](https://github.com/aws/aws-encryption-sdk-c/blob/master/include/aws/cryptosdk/materials.h)
-- [Javascript](https://github.com/awslabs/aws-encryption-sdk-javascript/blob/master/modules/material-management/src/cryptographic_material.ts)
 
-#### Structure
-
-Encryption materials are a structure containing materials needed for [encryption](#encrypt.md).
-This structure MAY include any of the following fields:
-
-- [Algorithm Suite](#algorith-suite)
-- [Encrypted Data Keys](#encrypted-data-keys)
-- [Encryption Context](#encryption-context)
-- [Keyring Trace](#keyring-trace)
-- [Plaintext Data Key](#plaintext-data-key)
-- [Signing Key](#signing-key)
 
 ##### Algorithm Suite
 
-The [algorithm suite](#algorithm-suites.md) to be used for [encryption](#encrypt.md).
-
-##### Encrypted Data Keys
-
-A list of the [encrypted data keys](#encrypted-data-key) that correspond to the plaintext data key.
-
-The [ciphertext](#ciphertext) of each encrypted data key in this list MUST be an opaque form of the
-plaintext data key from this set of encryption materials.
-
-If the plaintext data key is not included on this set of encryption materials, this list MUST be empty.
-
-##### Encryption Context
-
-The [encryption context](#encryption-context) associated with this [encryption](#encrypt.md).
-
-##### Keyring Trace
-
-A [keyring trace](#keyring-trace) containing all of the actions that keyrings have taken on this set
-of encryption materials.
+The [algorithm suite](#algorithm-suites.md) to be used for [encryption](#encrypt.md) or [decryption](#decrypt.md).
 
 ##### Plaintext Data Key
 
@@ -176,12 +147,51 @@ The plaintext data key SHOULD be stored as immutable data.
 
 The plaintext data key SHOULD offer an interface to zero the plaintext data key
 
+##### Encrypted Data Keys
+
+A list of the [encrypted data keys](#encrypted-data-key) that correspond to the plaintext data key.
+
+The [ciphertext](#ciphertext) of each encrypted data key in this list MUST be an opaque form of the
+plaintext data key from this set of data key materials.
+
+If the plaintext data key is not included on this set of encryption materials, this list MUST be empty.
+
+##### Keyring Trace
+
+An optional [keyring trace](#keyring-trace) containing all of the actions that keyrings have taken on this set of data key materials.
+
+### Encryption Materials
+
+#### Implementations
+
+- [Java](https://github.com/aws/aws-encryption-sdk-java/blob/master/src/main/java/com/amazonaws/encryptionsdk/model/EncryptionMaterials.java)
+- [Python](https://github.com/aws/aws-encryption-sdk-python/blob/master/src/aws_encryption_sdk/materials_managers/__init__.py)
+- [C](https://github.com/aws/aws-encryption-sdk-c/blob/master/include/aws/cryptosdk/materials.h)
+- [Javascript](https://github.com/awslabs/aws-encryption-sdk-javascript/blob/master/modules/material-management/src/cryptographic_material.ts)
+
+#### Structure
+
+Encryption materials are a structure containing materials needed for [encryption](#encrypt.md) or [decryption](#decrypt.md).
+This structure MAY include any of the following fields:
+
+- [Encryption Context](#encryption-context)
+- [Data Key Materials](#data-key-materials)
+- [Signing Key](#signing-key)
+
+##### Encryption Context
+
+The [encryption context](#encryption-context) associated with this [encryption](#encrypt.md) or [decryption](#decrypt.md).
+
+##### Data Key Materials
+
+The [data key materials](#data-key-materials) to be used in [encryption](#encrypt.md).
+
 ##### Signing Key
 
 The key to be used as the signing key for signature verification during [encryption](#encrypt.md).
 
 The signing key MUST fit the specification described by the [signature algorithm](#algorithm-suites.md#signature-algorithm)
-included in this encryption material's [algorithm suite](#algorithm-suite).
+included in this data key materials' [algorithm suite](#algorithm-suite).
 
 The value of this key MUST be kept secret.
 
@@ -211,7 +221,7 @@ The [algorithm suite](#algorithm-suites.md) to be used for [decryption](#decrypt
 
 ##### Encryption Context
 
-The [encryption context](#encryption-context) associated with this [encryption](#encrypt.md)
+The [encryption context](#encryption-context) associated with this [decryption](#encrypt.md)
 
 ##### Keyring Trace
 

--- a/framework/structures.md
+++ b/framework/structures.md
@@ -126,7 +126,9 @@ other AWS services.
 
 #### Implementations
 
+- [Java](https://github.com/aws/aws-encryption-sdk-java/blob/master/src/main/java/com/amazonaws/encryptionsdk/DataKey.java)
 
+TODO: The above is only a similar data structure related to the deprecated master key/master key provider concepts.
 
 ##### Algorithm Suite
 


### PR DESCRIPTION
https://github.com/awslabs/aws-encryption-sdk-specification/issues/53

The current specification defines the behaviour of the `Keyring` concept in terms of mutation side-effects on the `EncryptionMaterials` and `DecryptionMaterials` structures. This change refactors the `Keyring` interfaces to specify separate immutable input and output structures.

In order to do so, it introduces a new `Data Key Materials` concept that acts as the return value from `Keyring.OnEncrypt` and `Keyring.OnDecrypt`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
