### PR TITLE
Remove unneeded cmm interface precondition

### DIFF
--- a/framework/cmm-interface.md
+++ b/framework/cmm-interface.md
@@ -67,7 +67,6 @@ The decrypt materials request MUST include the following:
 
 - [Algorithm Suite](#algorithm-suite.md)
 - [Encrypted Data Keys](#structures.md#encrypted-data-keys)
-    - This list MUST contain at least one encrypted data key.
 - [Encryption Context](#encryption-context.md)
     - The encryption context provided MAY be empty.
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* We currently don't enforce this condition in any of our implementations, and I don't think it makes sense to add this requirement on the request, given that this sort of requirement isn't something most languages can even enforce. Additionally, restricting input in the CMM's requests isn't in line with our general philosophy that CMMs should be flexible.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
