### PR TITLE
chore: normalize copyright headers and add workflow to require that they are set

### DIFF
--- a/.github/not-grep.toml
+++ b/.github/not-grep.toml
@@ -1,0 +1,5 @@
+[prefix]
+"**/*.md" = """
+[//]: # (Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.)
+[//]: # (SPDX-License-Identifier: CC-BY-SA-4.0)
+"""

--- a/.github/workflows/ci_static-analysis.yaml
+++ b/.github/workflows/ci_static-analysis.yaml
@@ -1,0 +1,12 @@
+# This workflow performs static analysis checks.
+name: static analysis
+
+on: ["pull_request", "push"]
+
+jobs:
+  not-grep:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: not-grep
+        uses: mattsb42-meta/not-grep@1.0.0

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,6 @@
+[//]: # (Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.)
+[//]: # (SPDX-License-Identifier: CC-BY-SA-4.0)
+
 ## Code of Conduct
 This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct).
 For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,6 @@
+[//]: # (Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.)
+[//]: # (SPDX-License-Identifier: CC-BY-SA-4.0)
+
 # Contributing Guidelines
 
 Thank you for your interest in contributing to our project. Whether it's a bug report, new feature, correction, or additional

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[//]: # (Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.)
+[//]: # (SPDX-License-Identifier: CC-BY-SA-4.0)
+
 # AWS Encryption SDK Specification
 
 ## Overview

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,3 +1,6 @@
+[//]: # (Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.)
+[//]: # (SPDX-License-Identifier: CC-BY-SA-4.0)
+
 # Versioning Policy
 
 We use a three-part X.Y.Z (Major.Minor.Patch) versioning definition, as follows:

--- a/client-apis/decrypt.md
+++ b/client-apis/decrypt.md
@@ -1,4 +1,4 @@
-[//]: # (Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.)
+[//]: # (Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.)
 [//]: # (SPDX-License-Identifier: CC-BY-SA-4.0)
 
 # Decrypt

--- a/client-apis/encrypt.md
+++ b/client-apis/encrypt.md
@@ -1,4 +1,4 @@
-[//]: # (Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.)
+[//]: # (Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.)
 [//]: # (SPDX-License-Identifier: CC-BY-SA-4.0)
 
 # Encrypt

--- a/data-format/message-body-aad.md
+++ b/data-format/message-body-aad.md
@@ -1,4 +1,4 @@
-[//]: # (Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.)
+[//]: # (Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.)
 [//]: # (SPDX-License-Identifier: CC-BY-SA-4.0)
 
 # Message Body AAD

--- a/data-format/message-body.md
+++ b/data-format/message-body.md
@@ -1,4 +1,4 @@
-[//]: # (Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.)
+[//]: # (Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.)
 [//]: # (SPDX-License-Identifier: CC-BY-SA-4.0)
 
 # Message Body

--- a/data-format/message-footer.md
+++ b/data-format/message-footer.md
@@ -1,4 +1,4 @@
-[//]: # (Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.)
+[//]: # (Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.)
 [//]: # (SPDX-License-Identifier: CC-BY-SA-4.0)
 
 # Footer Structure

--- a/data-format/message-header.md
+++ b/data-format/message-header.md
@@ -1,4 +1,4 @@
-[//]: # (Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.)
+[//]: # (Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.)
 [//]: # (SPDX-License-Identifier: CC-BY-SA-4.0)
 
 #  Message Header

--- a/data-format/message.md
+++ b/data-format/message.md
@@ -1,4 +1,4 @@
-[//]: # (Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.)
+[//]: # (Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.)
 [//]: # (SPDX-License-Identifier: CC-BY-SA-4.0)
 
 # Message

--- a/framework/algorithm-suites.md
+++ b/framework/algorithm-suites.md
@@ -1,4 +1,4 @@
-[//]: # (Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.)
+[//]: # (Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.)
 [//]: # (SPDX-License-Identifier: CC-BY-SA-4.0)
 
 # Algorithm Suites

--- a/framework/caching-cmm.md
+++ b/framework/caching-cmm.md
@@ -1,4 +1,4 @@
-[//]: # (Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.)
+[//]: # (Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.)
 [//]: # (SPDX-License-Identifier: CC-BY-SA-4.0)
 
 # Caching Cryptographic Materials Manager

--- a/framework/cmm-interface.md
+++ b/framework/cmm-interface.md
@@ -1,4 +1,4 @@
-[//]: # (Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.)
+[//]: # (Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.)
 [//]: # (SPDX-License-Identifier: CC-BY-SA-4.0)
 
 # Cryptographic Materials Manager Interface

--- a/framework/cryptographic-materials-cache.md
+++ b/framework/cryptographic-materials-cache.md
@@ -1,4 +1,4 @@
-[//]: # (Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.)
+[//]: # (Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.)
 [//]: # (SPDX-License-Identifier: CC-BY-SA-4.0)
 
 # Cryptographic Materials Cache

--- a/framework/default-cmm.md
+++ b/framework/default-cmm.md
@@ -1,4 +1,4 @@
-[//]: # (Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.)
+[//]: # (Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.)
 [//]: # (SPDX-License-Identifier: CC-BY-SA-4.0)
 
 # Default Cryptographic Materials Manager

--- a/framework/keyring-interface.md
+++ b/framework/keyring-interface.md
@@ -1,4 +1,4 @@
-[//]: # (Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.)
+[//]: # (Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.)
 [//]: # (SPDX-License-Identifier: CC-BY-SA-4.0)
 
 # Keyring Interface

--- a/framework/kms-keyring.md
+++ b/framework/kms-keyring.md
@@ -1,4 +1,4 @@
-[//]: # (Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.)
+[//]: # (Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.)
 [//]: # (SPDX-License-Identifier: CC-BY-SA-4.0)
 
 # KMS Keyring

--- a/framework/master-key-interface.md
+++ b/framework/master-key-interface.md
@@ -1,4 +1,4 @@
-[//]: # (Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.)
+[//]: # (Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.)
 [//]: # (SPDX-License-Identifier: CC-BY-SA-4.0)
 
 # Master Key Interface

--- a/framework/master-key-provider-interface.md
+++ b/framework/master-key-provider-interface.md
@@ -1,4 +1,4 @@
-[//]: # (Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.)
+[//]: # (Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.)
 [//]: # (SPDX-License-Identifier: CC-BY-SA-4.0)
 
 # Master Key Provider Interface

--- a/framework/multi-keyring.md
+++ b/framework/multi-keyring.md
@@ -1,4 +1,4 @@
-[//]: # (Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.)
+[//]: # (Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.)
 [//]: # (SPDX-License-Identifier: CC-BY-SA-4.0)
 
 # Multi-Keyring

--- a/framework/raw-aes-keyring.md
+++ b/framework/raw-aes-keyring.md
@@ -1,4 +1,4 @@
-[//]: # (Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.)
+[//]: # (Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.)
 [//]: # (SPDX-License-Identifier: CC-BY-SA-4.0)
 
 # Raw AES Keyring

--- a/framework/raw-rsa-keyring.md
+++ b/framework/raw-rsa-keyring.md
@@ -1,4 +1,4 @@
-[//]: # (Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.)
+[//]: # (Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.)
 [//]: # (SPDX-License-Identifier: CC-BY-SA-4.0)
 
 # Raw RSA Keyring

--- a/framework/structures.md
+++ b/framework/structures.md
@@ -1,4 +1,4 @@
-[//]: # (Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.)
+[//]: # (Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.)
 [//]: # (SPDX-License-Identifier: CC-BY-SA-4.0)
 
 # Structures


### PR DESCRIPTION
*Description of changes:*

Workflow run on this commit on my fork: https://github.com/mattsb42-aws/aws-encryption-sdk-specification/actions/runs/110828472

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
