### PR TITLE
docs: Update Key IDs and generator sections to reference valid AWS KMS values, additional naming clarity

### DIFF
--- a/framework/kms-keyring.md
+++ b/framework/kms-keyring.md
@@ -115,12 +115,13 @@ The AWS KMS keyring accepts any value for a key name that is [accepted by AWS KM
 The AWS KMS keyring does not validate any value for a key name and passes this information to AWS KMS.
 
 Note that only key names in the [key ARN format](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-kms) are used for decryption
-because encrypted data keys constructed by the AWS KMS keyring always store the ID of the CMK used to encrypt it in the key ARN format.
-[OnDecrypt](#ondecrypt) checks the key name against that
+because encrypted data keys constructed by the AWS KMS keyring always store the ID of the CMK used to encrypt it in the key ARN format
+and [OnDecrypt](#ondecrypt) checks the key name against that
 value before attempting decryption.
 
-The AWS KMS caller using each AWS KMS CMK specified in the key names
-MUST have [kms:Encrypt](https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html#AWS-KMS-API-Operations-and-Permissions) permissions.
+The AWS KMS caller
+MUST have [kms:Encrypt](https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html#AWS-KMS-API-Operations-and-Permissions) permission
+for each AWS KMS CMK specified in the key names.
 
 ### Generator
 
@@ -131,15 +132,16 @@ The AWS KMS keyring accepts any value for a generator that is [accepted by AWS K
 The AWS KMS keyring does not validate any value for a generator and passes this information to AWS KMS.
 
 Note that only generators in the [key ARN format](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-kms) are used for decryption
-because encrypted data keys constructed by the AWS KMS keyring always store the ID of the CMK used to encrypt it in the key ARN format.
-[OnDecrypt](#ondecrypt) checks the generator against that
+because encrypted data keys constructed by the AWS KMS keyring always store the ID of the CMK used to encrypt it in the key ARN format
+and [OnDecrypt](#ondecrypt) checks the generator against that
 value before attempting decryption.
 
 The generator SHOULD NOT be included in the [key names](#key-names),
 otherwise this CMK is used to encrypt the plaintext data key twice.
 
-The AWS KMS caller using the AWS KMS CMK specified by the generator
-MUST have [kms:GenerateDataKey](https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html#AWS-KMS-API-Operations-and-Permissions) permissions.
+The AWS KMS caller
+MUST have [kms:GenerateDataKey](https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html#AWS-KMS-API-Operations-and-Permissions) permission
+for the AWS KMS CMK specified by the generator.
 
 ### Grant Tokens
 
@@ -157,8 +159,9 @@ The following is a derived property of the AWS KMS keyring:
 ### Is Discovery
 
 Indicates whether this keyring is a discovery keyring.
-Discovery keyrings do not perform encryption and on decryption attempt to decrypt every inputted
-[encrypted data key](structures.md#encrypted-data-key) if the client supplier return a client.
+Discovery keyrings do not perform encryption and on decryption attempt to decrypt
+any [encrypted data key](structures.md#encrypted-data-key) that was encrypted by the AWS KMS keyring,
+if the client supplier returns a client.
 
 If this keyring has defined a [generator](#generator) or [key names](#key-names), this value MUST be false.
 Otherwise, this value MUST be true.

--- a/framework/kms-keyring.md
+++ b/framework/kms-keyring.md
@@ -156,7 +156,7 @@ The following is a derived property of the AWS KMS keyring:
 ### Is Discovery
 
 Indicates whether this keyring is a discovery keyring.
-Discovery keyrings do not perform encryption, and on decryption attempt to decrypt every inputted
+Discovery keyrings do not perform encryption and on decryption attempt to decrypt every inputted
 [encrypted data key](structures.md#encrypted-data-key) if the client supplier return a client.
 
 If this keyring has defined a [generator](#generator) or [key names](#key-names), this value MUST be false.
@@ -225,7 +225,6 @@ For each [AWS KMS Encrypt](#aws-kms-encrypt) call, if an AWS region can be extra
 [AWS KMS client](#aws-kms-client) that calls [AWS KMS Encrypt](#aws-kms-encrypt) MUST be the client returned by the
 [client supplier](#client-supplier) when given that region as input.
 If an AWS region cannot be extracted from the key name then the AWS KMS Keyring MUST input a value denoting an unknown region.
-
 If the [client supplier](#client-supplier) does not provide any client
 for the given region for this [AWS KMS Encrypt](#aws-kms-encrypt) call,
 OnEncrypt MUST NOT modify the [encryption materials](structures.md#encryption-materials)

--- a/framework/kms-keyring.md
+++ b/framework/kms-keyring.md
@@ -13,6 +13,7 @@
 
   - Rename Key IDs to [Key Names](#key-names) for increased clarity
   - Update [Key Names](#key-names) and [Generator](#generator) sections to reinforce support for all AWS KMS key identifiers
+  - [Pull request link for discussion](https://github.com/awslabs/aws-encryption-sdk-specification/pull/123)
 
 - 0.2.1
 

--- a/framework/kms-keyring.md
+++ b/framework/kms-keyring.md
@@ -13,7 +13,7 @@
 
   - Rename Key IDs to [Key Names](#key-names) for increased clarity
   - Update [Key Names](#key-names) and [Generator](#generator) sections to reinforce support for all AWS KMS key identifiers
-  - [Pull request link for discussion](https://github.com/awslabs/aws-encryption-sdk-specification/pull/123)
+  - [Pull request link for discussions](https://github.com/awslabs/aws-encryption-sdk-specification/pull/123)
 
 - 0.2.1
 

--- a/framework/kms-keyring.md
+++ b/framework/kms-keyring.md
@@ -5,11 +5,11 @@
 
 ## Version
 
-0.3.0
+0.2.1
 
 ### Changelog
 
-- 0.3.0
+- 0.2.1
 
   - Rename Key IDs to [Key Names](#key-names) for increased clarity
   - Update [Key Names](#key-names) and [Generator](#generator) sections to reinforce support for all AWS KMS key identifiers
@@ -101,38 +101,38 @@ it MUST communicate that fact to the KMS keyring.
 
 ### Key Names
 
-The key name identifies the [AWS KMS customer master keys (CMKs)](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id)
-that the AWS KMS keyring uses for data key encryption and decryption.
+A list of strings identifying the [AWS KMS customer master keys (CMKs)](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id)
+that the AWS KMS keyring uses to encrypt and decrypt data keys.
 
-The AWS KMS keyring accepts all [key identifiers accepted by AWS KMS](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id) as key names.
+The AWS KMS keyring accepts any value for a key name that is [accepted by AWS KMS as a key identifer](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id).
+The AWS KMS keyring does not validate any value for a key name and passes this information to AWS KMS.
 
-Note that only key names in the [key ARN format](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-kms) will ever be used for decryption.
-This is because encrypted data keys constructed by the AWS KMS keyring will always store the ID of the
-CMK used to encrypt it in key ARN format, and [OnDecrypt](#ondecrypt) checks the key name against that
+Note that only key names in the [key ARN format](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-kms) are used for decryption
+because encrypted data keys constructed by the AWS KMS keyring always store the ID of the CMK used to encrypt it in the key ARN format.
+[OnDecrypt](#ondecrypt) checks the key name against that
 value before attempting decryption.
 
-The AWS KMS CMK specified by the key names MUST have
-[kms:Encrypt](https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html#AWS-KMS-API-Operations-and-Permissions)
-permissions.
+The AWS KMS caller using each AWS KMS CMK specified in the key names
+MUST have [kms:Encrypt](https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html#AWS-KMS-API-Operations-and-Permissions) permissions.
 
 ### Generator
 
-A string that identifies an [AWS KMS customer master key (CMK)](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id) that the AWS KMS keyring uses for data key generation,
-as well as data key encryption and decryption.
+A string that identifies an [AWS KMS customer master key (CMK)](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id)
+that the AWS KMS keyring uses to generate, encrypt, and decrypt data keys.
 
-The AWS KMS keyring accepts any [key identifier accepted by AWS KMS](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id) as a generator.
+The AWS KMS keyring accepts any value for a generator that is [accepted by AWS KMS as a key identifer](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id).
+The AWS KMS keyring does not validate any value for a generator and passes this information to AWS KMS.
 
-Note that only generators in the [key ARN format](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-kms) will ever be used for decryption.
-This is because encrypted data keys constructed by the AWS KMS keyring will always store the ID of the
-CMK used to encrypt it in key ARN format, and [OnDecrypt](#ondecrypt) checks the generator against that
+Note that only generators in the [key ARN format](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-kms) are used for decryption
+because encrypted data keys constructed by the AWS KMS keyring always store the ID of the CMK used to encrypt it in the key ARN format.
+[OnDecrypt](#ondecrypt) checks the generator against that
 value before attempting decryption.
 
-The generator SHOULD NOT be included in the [key names](#key-names), otherwise this CMK will be used
-twice to encrypt the plaintext data key.
+The generator SHOULD NOT be included in the [key names](#key-names),
+otherwise this CMK is used to encrypt the plaintext data key twice.
 
-The KMS CMK specified by the generator MUST have
-[kms:GenerateDataKey](https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html#AWS-KMS-API-Operations-and-Permissions)
-permissions.
+The AWS KMS caller using the AWS KMS CMK specified by the generator
+MUST have [kms:GenerateDataKey](https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html#AWS-KMS-API-Operations-and-Permissions) permissions.
 
 ### Grant Tokens
 

--- a/framework/kms-keyring.md
+++ b/framework/kms-keyring.md
@@ -150,7 +150,7 @@ The following is a derived property of the KMS-keyring:
 ### Is Discovery
 
 Indicates whether this keyring is a discovery keyring.
-Discovery keyrings do not perform encryption, and on decryption will attempt to decrypt every inputted
+Discovery keyrings do not perform encryption, and on decryption attempt to decrypt every inputted
 [encrypted data key](structures.md#encrypted-data-key) if the client supplier return a client.
 
 If this keyring has defined a [generator](#generator) or [key names](#key-names), this value MUST be false.
@@ -333,12 +333,12 @@ one from CMK A, one from CMK B, and one from CMK C.
 
 When a user configures a KMS keyring for use on decrypt,
 they are stating their intent for which CMKs
-the keyring will _attempt_ to use to decrypt encrypted data keys.
+the keyring _attempts_ to use to decrypt encrypted data keys.
 
 For example, if a user configures a KMS keyring with CMK C (using the CMK ARN)
 and uses it to decrypt an encrypted message
 that contains encrypted data keys for CMKs A, B, and C,
-then the keyring will attempt to decrypt using CMK C.
+then the keyring attempts to decrypt using CMK C.
 
 However, if the keyring attempts to decrypt using CMK C and cannot,
 this failure still honors the configured intent and MUST NOT halt decryption.
@@ -365,7 +365,7 @@ If the keyring cannot satisfy those requirements it MUST NOT halt message decryp
 No keyring can know if it is the last keyring to attempt decryption.
 If all keyrings are exhausted and none of them were able to decrypt an encrypted data key
 then the cryptographic materials manager that managed those keyrings
-will halt message decryption.
+halts message decryption.
 (See [Default Cryptographic Materials Manager](./default-cmm.md))
 
 ### Requirements


### PR DESCRIPTION
_Issue #, if available:_
* https://github.com/awslabs/aws-encryption-sdk-specification/issues/68
* https://github.com/awslabs/aws-encryption-sdk-specification/issues/55

_Description of changes:_
* Rename Key IDs to Key Names for increased clarity
* Update Key Names and Generator sections to reinforce support for all AWS KMS key identifiers

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
