### PR TITLE
docs: add change doc to describe key namespaces, names, provider IDs, and provider info

### DIFF
--- a/changes/2020-06-09_wrapping-key-identifiers/change.md
+++ b/changes/2020-06-09_wrapping-key-identifiers/change.md
@@ -88,9 +88,7 @@ This change SHOULD NOT have any security implications.
 
 ## Operational Implications
 
-If the keyring chooses to write a provider info value that does not equal its key name,
-that keyring's behavior can be more complex for customers to configure
-than if they are the same.
+This change SHOULD NOT have any operational implications.
 
 ## Guide-level Explanation
 

--- a/changes/2020-06-09_wrapping-key-identifiers/change.md
+++ b/changes/2020-06-09_wrapping-key-identifiers/change.md
@@ -92,7 +92,7 @@ This change SHOULD NOT have any operational implications.
 
 ## Guide-level Explanation
 
-Key namespace and key name are configuration values that MAY determine the behavior of a keyring.
+Key namespace and key name are configuration values that determine the behavior of a keyring.
 
 Provider ID and provider info are values that identify the keyring configuration
 that can fulfill the keyring's decryption contract.
@@ -100,7 +100,7 @@ The keyring attaches these values to the encrypted data key ciphertext.
 
 ## Reference-level Explanation
 
-"Key namespace", "key name", "provider ID", "provider info"
+"Key namespace", "key name", "provider ID", and "provider info"
 are all concepts that identify a wrapping key.
 
 ### key namespace
@@ -109,11 +109,15 @@ A configuration value for a keyring
 that identifies the grouping or categorization
 for the wrapping keys that keyring can access.
 
+The key namespace MUST be a string value.
+
 ### key name
 
 A configuration value for a keyring
 that identifies a single wrapping key
 within a key namespace.
+
+The key name MUST be a string value.
 
 ### provider ID
 
@@ -122,7 +126,8 @@ as part of an encrypted data key structure
 that identifies the grouping or categorization
 for the keyring that can fulfill this keyring's decryption contract.
 
-The provider ID SHOULD be equal to the key namespace.
+The provider ID MUST be a binary value
+and SHOULD be equal to a UTF-8 encoding of the key namespace.
 
 ### provider info
 
@@ -131,14 +136,15 @@ as part of an encrypted data key structure
 that provides necessary information for a keyring
 to fulfill this keyring's decryption contract.
 
-The provider info SHOULD be equal to the key name.
+The provider info MUST be a binary value
+and SHOULD be equal to a UTF-8 encoding of the key name.
 
 One example of a keyring where the key name and provider info can differ
 is the AWS KMS keyring.
 This keyring uses its key name to identify the desired CMK in its call to AWS KMS.
 However, the provider info that this keyring writes is
 the CMK identifier that AWS KMS includes in its response.
-If the key name is a CMK ARN these two values are identical
+If the key name is a CMK ARN, these two values are identical
 because this response value is always the CMK ARN of the CMK that AWS KMS used.
 However, if the key name is some other valid CMK identifier,
 such as an alias,

--- a/changes/2020-06-09_wrapping-key-identifiers/change.md
+++ b/changes/2020-06-09_wrapping-key-identifiers/change.md
@@ -124,7 +124,7 @@ The key name MUST be a string value.
 An output value returned by a keyring on encrypt
 as part of an encrypted data key structure
 that identifies the grouping or categorization
-for the keyring that can fulfill this keyring's decryption contract.
+for a keyring that can fulfill this decryption contract.
 
 The provider ID MUST be a binary value
 and SHOULD be equal to a UTF-8 encoding of the key namespace.
@@ -134,7 +134,7 @@ and SHOULD be equal to a UTF-8 encoding of the key namespace.
 An output value returned by a keyring on encrypt
 as part of an encrypted data key structure
 that provides necessary information for a keyring
-to fulfill this keyring's decryption contract.
+to fulfill this decryption contract.
 
 The provider info MUST be a binary value
 and SHOULD be equal to a UTF-8 encoding of the key name.

--- a/changes/2020-06-09_wrapping-key-identifiers/change.md
+++ b/changes/2020-06-09_wrapping-key-identifiers/change.md
@@ -94,9 +94,9 @@ This change SHOULD NOT have any operational implications.
 
 Key namespace and key name are configuration values that determine the behavior of a keyring.
 
-Provider ID and key provider info are values that identify the keyring configuration
+Key provider ID and key provider info are values that identify the keyring configuration
 that can fulfill the keyring's decryption contract.
-The keyring attaches these values to the encrypted data key ciphertext.
+The keyring attaches these values to a data key ciphertext to form an encrypted data key.
 
 ## Reference-level Explanation
 

--- a/changes/2020-06-09_wrapping-key-identifiers/change.md
+++ b/changes/2020-06-09_wrapping-key-identifiers/change.md
@@ -50,8 +50,8 @@ We have referenced several terms throughout various specification documents
 that are never defined:
 "key namespace",
 "key name",
-"provider ID",
-and "provider info".
+"key provider ID",
+and "key provider info".
 This change defines each of these terms
 and describes their relationships to each other
 and the keyrings they represent.
@@ -67,8 +67,8 @@ and the keyrings they represent.
 Various specification documents reference
 "key namespace",
 "key name",
-"provider ID",
-and "provider info",
+"key provider ID",
+and "key provider info",
 but we never define what these terms mean
 or how they relate to each other.
 
@@ -94,13 +94,13 @@ This change SHOULD NOT have any operational implications.
 
 Key namespace and key name are configuration values that determine the behavior of a keyring.
 
-Provider ID and provider info are values that identify the keyring configuration
+Provider ID and key provider info are values that identify the keyring configuration
 that can fulfill the keyring's decryption contract.
 The keyring attaches these values to the encrypted data key ciphertext.
 
 ## Reference-level Explanation
 
-"Key namespace", "key name", "provider ID", and "provider info"
+"Key namespace", "key name", "key provider ID", and "key provider info"
 are all concepts that identify a wrapping key.
 
 ### key namespace
@@ -119,30 +119,30 @@ within a key namespace.
 
 The key name MUST be a string value.
 
-### provider ID
+### key provider ID
 
 An output value returned by a keyring on encrypt
 as part of an encrypted data key structure
 that identifies the grouping or categorization
 for a keyring that can fulfill this decryption contract.
 
-The provider ID MUST be a binary value
+The key provider ID MUST be a binary value
 and SHOULD be equal to a UTF-8 encoding of the key namespace.
 
-### provider info
+### key provider info
 
 An output value returned by a keyring on encrypt
 as part of an encrypted data key structure
 that provides necessary information for a keyring
 to fulfill this decryption contract.
 
-The provider info MUST be a binary value
+The key provider info MUST be a binary value
 and SHOULD be equal to a UTF-8 encoding of the key name.
 
-One example of a keyring where the key name and provider info can differ
+One example of a keyring where the key name and key provider info can differ
 is the AWS KMS keyring.
 This keyring uses its key name to identify the desired CMK in its call to AWS KMS.
-However, the provider info that this keyring writes is
+However, the key provider info that this keyring writes is
 the CMK identifier that AWS KMS includes in its response.
 If the key name is a CMK ARN, these two values are identical
 because this response value is always the CMK ARN of the CMK that AWS KMS used.

--- a/changes/2020-06-09_wrapping-key-identifiers/change.md
+++ b/changes/2020-06-09_wrapping-key-identifiers/change.md
@@ -1,0 +1,147 @@
+[//]: # "Copyright Amazon.com Inc. or its affiliates. All Rights Reserved."
+[//]: # "SPDX-License-Identifier: CC-BY-SA-4.0"
+
+# Clarify Wrapping Key Identifiers
+
+## Affected Features
+
+This serves as a reference of all features that this change affects.
+
+| Feature                                                                                             |
+| --------------------------------------------------------------------------------------------------- |
+| [Encrypted Data Key](../../framework/structures.md#encrypted-data-key)                              |
+| [AWS KMS Keyring](../../framework/kms-keyring.md)                                                   |
+| [Raw AES Keyring](../../framework/raw-aes-keyring.md)                                               |
+| [Raw RSA Keyring](../../framework/raw-rsa-keyring.md)                                               |
+| [Keyring Decryption Contract](https://github.com/awslabs/aws-encryption-sdk-specification/pull/131) |
+
+## Affected Specifications
+
+This serves as a reference of all specification documents that this change affects.
+
+| Specification                                             |
+| --------------------------------------------------------- |
+| [Structures](../../framework/structures.md)               |
+| [Keyring Interface](../../framework/keyring-interface.md) |
+| [AWS KMS Keyring](../../framework/kms-keyring.md)         |
+| [Raw AES Keyring](../../framework/raw-aes-keyring.md)     |
+| [Raw RSA Keyring](../../framework/raw-rsa-keyring.md)     |
+
+## Affected Implementations
+
+The scope of this change only affects the specification.
+Follow-up changes that define
+whether implementations expose these concepts
+MAY affect implementations.
+
+## Definitions
+
+### Conventions used in this document
+
+The key words
+"MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+"SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL"
+in this document are to be interpreted as described in
+[RFC 2119](https://tools.ietf.org/html/rfc2119).
+
+## Summary
+
+We have referenced several terms throughout various specification documents
+that are never defined:
+"key namespace",
+"key name",
+"provider ID",
+and "provider info".
+This change defines each of these terms
+and describes their relationships to each other
+and the keyrings they represent.
+
+## Out of Scope
+
+- Whether, or how, each keyring exposes any of these values at runtime is out of scope.
+
+- Specific values for these terms for any specific keyring is out of scope.
+
+## Motivation
+
+Various specification documents reference
+"key namespace",
+"key name",
+"provider ID",
+and "provider info",
+but we never define what these terms mean
+or how they relate to each other.
+
+In order to ensure the specification documents accurately describe keyring behavior,
+we need to define all terms that they use.
+
+## Drawbacks
+
+This change SHOULD NOT introduce any drawbacks.
+It is identifying and describing
+terms that already exist
+and the existing relationship between them.
+
+## Security Implications
+
+This change SHOULD NOT have any security implications.
+
+## Operational Implications
+
+If the keyring chooses to write a provider info value that does not equal its key name,
+that keyring's behavior can be more complex for customers to configure
+than if they are the same.
+
+## Guide-level Explanation
+
+Key namespace and key name are configuration values that MAY determine the behavior of a keyring.
+
+Provider ID and provider info are values that identify the keyring configuration
+that can fulfill the keyring's decryption contract.
+The keyring attaches these values to the encrypted data key ciphertext.
+
+## Reference-level Explanation
+
+"Key namespace", "key name", "provider ID", "provider info"
+are all concepts that identify a wrapping key.
+
+### key namespace
+
+A configuration value for a keyring
+that identifies the grouping or categorization
+for the wrapping keys that keyring can access.
+
+### key name
+
+A configuration value for a keyring
+that identifies a single wrapping key
+within a key namespace.
+
+### provider ID
+
+An output value returned by a keyring on encrypt
+as part of an encrypted data key structure
+that identifies the grouping or categorization
+for the keyring that can fulfill this keyring's decryption contract.
+
+The provider ID SHOULD be equal to the key namespace.
+
+### provider info
+
+An output value returned by a keyring on encrypt
+as part of an encrypted data key structure
+that provides necessary information for a keyring
+to fulfill this keyring's decryption contract.
+
+The provider info SHOULD be equal to the key name.
+
+One example of a keyring where the key name and provider info can differ
+is the AWS KMS keyring.
+This keyring uses its key name to identify the desired CMK in its call to AWS KMS.
+However, the provider info that this keyring writes is
+the CMK identifier that AWS KMS includes in its response.
+If the key name is a CMK ARN these two values are identical
+because this response value is always the CMK ARN of the CMK that AWS KMS used.
+However, if the key name is some other valid CMK identifier,
+such as an alias,
+then they are different.

--- a/framework/keyring-interface.md
+++ b/framework/keyring-interface.md
@@ -5,9 +5,13 @@
 
 ## Version
 
-0.2.1
+0.2.2
 
 ### Changelog
+
+- 0.2.2
+
+  - [Define wrapping key identifier terms](../changes/2020-06-09_wrapping-key-identifiers/change.md)
 
 - 0.2.1
 
@@ -42,6 +46,42 @@ The keyring interface specified in this document describes the interface all key
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL"
 in this document are to be interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
+
+### key namespace
+
+A configuration value for a keyring
+that identifies the grouping or categorization
+for the wrapping keys that keyring can access.
+
+The key namespace MUST be a string value.
+
+### key name
+
+A configuration value for a keyring
+that identifies a single wrapping key
+within a key namespace.
+
+The key name MUST be a string value.
+
+### provider ID
+
+An output value returned by a keyring on encrypt
+as part of an encrypted data key structure
+that identifies the grouping or categorization
+for the keyring that can fulfill this keyring's decryption contract.
+
+The provider ID MUST be a binary value
+and SHOULD be equal to a UTF-8 encoding of the key namespace.
+
+### provider info
+
+An output value returned by a keyring on encrypt
+as part of an encrypted data key structure
+that provides necessary information for a keyring
+to fulfill this keyring's decryption contract.
+
+The provider info MUST be a binary value
+and SHOULD be equal to a UTF-8 encoding of the key name.
 
 ## Supported Keyrings
 

--- a/framework/keyring-interface.md
+++ b/framework/keyring-interface.md
@@ -63,24 +63,24 @@ within a key namespace.
 
 The key name MUST be a string value.
 
-### provider ID
+### key provider ID
 
 An output value returned by a keyring on encrypt
 as part of an encrypted data key structure
 that identifies the grouping or categorization
 for a keyring that can fulfill this decryption contract.
 
-The provider ID MUST be a binary value
+The key provider ID MUST be a binary value
 and SHOULD be equal to a UTF-8 encoding of the key namespace.
 
-### provider info
+### key provider info
 
 An output value returned by a keyring on encrypt
 as part of an encrypted data key structure
 that provides necessary information for a keyring
 to fulfill this decryption contract.
 
-The provider info MUST be a binary value
+The key provider info MUST be a binary value
 and SHOULD be equal to a UTF-8 encoding of the key name.
 
 ## Supported Keyrings

--- a/framework/keyring-interface.md
+++ b/framework/keyring-interface.md
@@ -73,6 +73,9 @@ for a keyring that can fulfill this decryption contract.
 The key provider ID MUST be a binary value
 and SHOULD be equal to a UTF-8 encoding of the key namespace.
 
+This value MUST NOT be "aws-kms"
+unless this encrypted data key was produced by the [AWS KMS Keyring](kms-keyring.md).
+
 ### key provider info
 
 An output value returned by a keyring on encrypt

--- a/framework/keyring-interface.md
+++ b/framework/keyring-interface.md
@@ -68,7 +68,7 @@ The key name MUST be a string value.
 An output value returned by a keyring on encrypt
 as part of an encrypted data key structure
 that identifies the grouping or categorization
-for the keyring that can fulfill this keyring's decryption contract.
+for a keyring that can fulfill this decryption contract.
 
 The provider ID MUST be a binary value
 and SHOULD be equal to a UTF-8 encoding of the key namespace.
@@ -78,7 +78,7 @@ and SHOULD be equal to a UTF-8 encoding of the key namespace.
 An output value returned by a keyring on encrypt
 as part of an encrypted data key structure
 that provides necessary information for a keyring
-to fulfill this keyring's decryption contract.
+to fulfill this decryption contract.
 
 The provider info MUST be a binary value
 and SHOULD be equal to a UTF-8 encoding of the key name.

--- a/framework/raw-aes-keyring.md
+++ b/framework/raw-aes-keyring.md
@@ -50,21 +50,9 @@ Galois/Counter Mode (GCM) Specification: [NIST Special Publication 800-38D](http
 
 On keyring initialization, the following inputs are REQUIRED:
 
-- [Key Namespace](#key-namespace)
-- [Key Name](#key-name)
+- [Key Namespace](./keyring-interface.md#key-namespace)
+- [Key Name](./keyring-interface.md#key-name)
 - [Wrapping Key](#wrapping-key)
-
-### Key Namespace
-
-A UTF-8 encoded value that, together with the [key name](#key-name), identifies a particular [wrapping key](#wrapping-key).
-
-This value is also used for bookkeeping purposes.
-
-### Key Name
-
-A UTF-8 encoded value that, together with the [key namespace](#key-namespace), identifies a particular [wrapping key](#wrapping-key).
-
-This value is also used for bookkeeping purposes.
 
 ### Wrapping Key
 
@@ -85,16 +73,16 @@ This structure is a sequence of bytes in big-endian format to be used as the
 The following table describes the fields that form the raw AES keyring key provider information.
 The bytes are appended in the order shown.
 
-| Field                     | Length (bytes)                  | Interpreted as      |
-| ------------------------- | ------------------------------- | ------------------- |
-| Key Name                  | length of [Key Name](#key-name) | UTF-8 encoded bytes |
-| Authentication Tag Length | 4                               | UInt32              |
-| IV Length                 | 4                               | UInt32              |
-| IV                        | [IV Length](#iv-length)         | Bytes               |
+| Field                     | Length (bytes)                                        | Interpreted as      |
+| ------------------------- | ----------------------------------------------------- | ------------------- |
+| Key Name                  | length of [Key Name](./keyring-interface.md#key-name) | UTF-8 encoded bytes |
+| Authentication Tag Length | 4                                                     | UInt32              |
+| IV Length                 | 4                                                     | UInt32              |
+| IV                        | [IV Length](#iv-length)                               | Bytes               |
 
 #### Key Name
 
-The [Key Name](#key-name) of this keyring.
+The [Key Name](./keyring-interface.md#key-name) of this keyring.
 
 #### Authentication Tag Length
 
@@ -158,7 +146,7 @@ The keyring must use AES-GCM with the following specifics:
 Based on the ciphertext output of the AES-GCM decryption,
 the keyring MUST construct an [encrypted data key](structures.md#encrypted-data-key) with the following specifics:
 
-- the [key provider ID](structures.md#key-provider-id) is this keyring's [key namespace](#key-namespace)
+- the [key provider ID](structures.md#key-provider-id) is this keyring's [key namespace](./keyring-interface.md#key-namespace)
 - the [key provider information](structures.md#key-provider-information) is serialized as the
   [raw AES keyring key provider information](#key-provider-information)
 - the [ciphertext](structures.md#ciphertext) is serialized as the
@@ -180,14 +168,14 @@ in the input encrypted data key list, serially, until it successfully decrypts o
 For each [encrypted data key](structures.md#encrypted-data-key),
 the keyring MUST first attempt to deserialize the [serialized ciphertext](#ciphertext)
 to obtain the [encrypted key](#encrypted-key) and [authentication tag](#authentication-tag), and
-deserialize the [serialized key provider info](#key-provider-information) to obtain the [key name](#key-name),
+deserialize the [serialized key provider info](#key-provider-information) to obtain the [key name](./keyring-interface.md#key-name),
 [IV](#iv), [IV length](#iv-length), and [authentication tag length](#authentication-tag-length).
 
 The keyring MUST attempt to decrypt the encrypted data key if and only if the following is true:
 
 - the [ciphertext](#ciphertext) and [key provider information](#key-provider-information) are successfully deserialized.
-- the key name obtained from the encrypted data key's key provider information has a value equal to this keyring's [key name](#key-name).
-- the key provider ID of the encrypted data key has a value equal to this keyring's [key namespace](#key-namespace).
+- the key name obtained from the encrypted data key's key provider information has a value equal to this keyring's [key name](./keyring-interface.md#key-name).
+- the key provider ID of the encrypted data key has a value equal to this keyring's [key namespace](./keyring-interface.md#key-namespace).
 - the [IV length](#iv-length) obtained from the encrypted data key's key provider information has a value equal to 12.
 - the [authentication tag length](#authentication-tag-length) obtained from the key provider information has a value equal to 128.
 

--- a/framework/raw-rsa-keyring.md
+++ b/framework/raw-rsa-keyring.md
@@ -48,18 +48,10 @@ RSA Implementation Specification: [RFC 3447](https://tools.ietf.org/html/rfc8017
 
 On keyring initialization, the following inputs are REQUIRED:
 
-- [Key Namespace](#key-namespace)
-- [Key Name](#key-name)
+- [Key Namespace](./keyring-interface.md#key-namespace)
+- [Key Name](./keyring-interface.md#key-name)
 - [Padding Scheme](#padding-scheme)
 - [Public Key](#public-key) and/or [Private Key](#private-key)
-
-### Key Namespace
-
-A UTF-8 encoded value that namespaces this keyring.
-
-### Key Name
-
-A UTF-8 encoded value that names this keyring.
 
 ### Padding Scheme
 

--- a/framework/structures.md
+++ b/framework/structures.md
@@ -73,25 +73,13 @@ and vice versa MAY be any reversible operation, though we expect that most will 
 
 ##### Key Provider ID
 
-A UTF-8 encoded value related to the key provider that encrypted this data key.
-
-This value usually represents the namespace of the key provider defined wrapping key
-used to encrypt the plaintext data key.
-
-For example, [encrypted data keys](#encrypted-data-key) encrypted by the [AWS KMS Keyring](kms-keyring.md)
-have the value of "aws-kms" in this field.
-
-This value MUST NOT be "aws-kms" unless this encrypted data key was produced by the [AWS KMS Keyring](kms-keyring.md).
+The [key provider ID](keyring-interface.md#key-provider-id) value
+for the keyring that wrote this encrypted data key.
 
 ##### Key Provider Information
 
-Information related to the key provider.
-Its structure and meaning is specified by the key provider that encrypted this data key.
-
-This is usually a UTF-8 encoded value.
-This value is usually the name of a key provider defined wrapping key that is used to encrypt the plaintext data key.
-However, the [raw AES keyring](raw-aes-keyring.md) defines a specific structure for the key provider information
-that includes more information.
+The [key provider info](keyring-interface.md#key-provider-info) value
+for the keyring that wrote this encrypted data key.
 
 ##### Ciphertext
 


### PR DESCRIPTION
_Issue #, if available:_
resolves: #21 
resolves: #47 

_Description of changes:_

This change introduces definitions of the terms "key namespace", "key name", "provider ID", and "provider info", as well as  how they relate to each other.

**NOTE: I have not yet altered the keyring spec doc. That needs to happen before this merges.**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
