### PR TITLE
doc(Raw Keyrings): Raw keyrings MUST NOT accept a key namespace of "aws-kms"

### DIFF
--- a/framework/raw-aes-keyring.md
+++ b/framework/raw-aes-keyring.md
@@ -5,9 +5,13 @@
 
 ## Version
 
-0.2.0
+0.3.0
 
 ### Changelog
+
+- 0.3.0
+
+  - [Raw AES keyring MUST NOT accept a key namespace of "aws-kms".](https://github.com/awslabs/aws-encryption-sdk-specification/issues/101)
 
 - 0.2.0
 
@@ -57,6 +61,8 @@ On keyring initialization, the following inputs are REQUIRED:
 ### Key Namespace
 
 A UTF-8 encoded value that, together with the [key name](#key-name), identifies a particular [wrapping key](#wrapping-key).
+
+The raw AES keyring MUST NOT accept a key namespace of "aws-kms".
 
 This value is also used for bookkeeping purposes.
 

--- a/framework/raw-rsa-keyring.md
+++ b/framework/raw-rsa-keyring.md
@@ -5,9 +5,13 @@
 
 ## Version
 
-0.2.0
+0.3.0
 
 ### Changelog
+
+- 0.3.0
+
+  - [Raw RSA keyring MUST NOT accept a key namespace of "aws-kms".](https://github.com/awslabs/aws-encryption-sdk-specification/issues/101)
 
 - 0.2.0
 
@@ -57,9 +61,15 @@ On keyring initialization, the following inputs are REQUIRED:
 
 A UTF-8 encoded value that namespaces this keyring.
 
+The raw RSA keyring MUST NOT accept a key namespace of "aws-kms".
+
+This value is also used for bookkeeping purposes.
+
 ### Key Name
 
 A UTF-8 encoded value that names this keyring.
+
+This value is also used for bookkeeping purposes.
 
 ### Padding Scheme
 


### PR DESCRIPTION
_Issue #, if available:_ Resolves #101 

_Description of changes:_
- Clarify that Raw keyrings (raw AES keyring and raw RSA keyring) "MUST NOT" accept a key namespace value of `"aws-kms"`
- Bump the minor version of raw AES keyring and raw RSA keyring

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
