### PR TITLE
fix: Replace “children keyrings” with “child keyrings”

### DIFF
--- a/framework/multi-keyring.md
+++ b/framework/multi-keyring.md
@@ -36,7 +36,7 @@ in this document are to be interpreted as described in [RFC 2119](https://tools.
 On keyring initialization, a keyring MUST define at least one of the following:
 
 - [Generator Keyring](#generator-keyring)
-- [Children Keyrings](#children-keyrings)
+- [Child Keyrings](#child-keyrings)
 
 ### Generator Keyring
 
@@ -47,10 +47,10 @@ during [OnEncrypt](keyring-interface.md#onencrypt).
 This means that this keyring MUST return [encryption materials](structures.md#encryption-materials) containing
 a plaintext data key on [OnEncrypt](keyring-interface.md#onencrypt).
 
-If the list of [children keyrings](#children-keyrings) is empty,
+If the list of [child keyrings](#child-keyrings) is empty,
 a [generator keyring](#generator-keyring) MUST be defined for the keyring.
 
-### Children Keyrings
+### Child Keyrings
 
 A list of [keyrings](keyring-interface.md) to be used to modify the [encryption](structures.md#encryption-materials)
 or [decryption materials](structures.md#decryption-materials).
@@ -72,7 +72,7 @@ If this keyring does not have a [generator keyring](#generator-keyring),
 and the input [encryption materials](structures.md#encryption-materials)
 does not include a plaintext data key, OnEncrypt MUST fail.
 
-Next, for each [keyring](keyring-interface.md) in this keyring's [children keyrings](#children-keyrings),
+Next, for each [keyring](keyring-interface.md) in this keyring's list of [child keyrings](#child-keyrings),
 the keyring MUST call [OnEncrypt](keyring-interface.md#onencrypt).
 The [encryption materials](structures.md#encryption-materials) inputted into OnEncrypt is the
 input encryption materials if this is the first OnEncrypt call.
@@ -90,7 +90,7 @@ OnDecrypt MUST immediately return the unmodified decryption materials.
 
 Otherwise, OnDecrypt MUST attempt to decrypt the [encrypted data keys](structures.md#encrypted-data-keys-1)
 in the input [decryption materials](structures.md#decryption-materials) using it's
-[children keyrings](#children-keyrings) and, if it is specified, [generator keyring](#generator-keyring).
+[child keyrings](#child-keyrings) and, if it is specified, [generator keyring](#generator-keyring).
 It MUST attempt to decrypt using these keyrings until it either succeeds in decryption,
 or it has no more child keyrings or generator keyring to attempt decryption with.
 If a generator keyring is specified, it MUST be used first.
@@ -102,7 +102,7 @@ the unmodified [decryption materials](structures.md#decryption-materials) and in
 If [OnDecrypt](keyring-interface.md#ondecrypt) returns [decryption materials](structures.md#decryption-materials)
 containing a plaintext data key, the keyring MUST immediately return the modified decryption materials.
 
-If, after calling [OnDecrypt](keyring-interface.md#ondecrypt) on every one of this keyring's [children keyrings](#children-keyrings)
+If, after calling [OnDecrypt](keyring-interface.md#ondecrypt) on every one of this keyring's [child keyrings](#child-keyrings)
 (and possibly the [generator keyring](#generator-keyring)), the [decryption materials](structures.md#decryption-materials)
 still do not contain a plaintext data key:
 
@@ -124,7 +124,7 @@ In more detail:
 
 Multi-keyrings will produce a set of [encrypted data keys](structures.md#encrypted-data-key) on
 [OnEncrypt](keyring-interface.md#onencrypt) that includes the encrypted data keys of every sub-keyring
-(a keyring which is either the [generator keyring](#generator-keyring) or a member of [children keyrings](#children-keyrings))
+(a keyring which is either the [generator keyring](#generator-keyring) or a member of [child keyrings](#child-keyrings))
 that is capable of producing encrypted data keys.
 
 As such, any [keyring](keyring-interface.md) that is capable of obtaining the plaintext data key from


### PR DESCRIPTION
Fixes #115

Also a couple of minor grammar/readability fixes.

Note that renaming the sub-heading breaks the existing #children-keyrings anchor. I'm making the assumption that this is allowable given all current references are within this feature document. If that's not the case I can add an explicit anchor with the old symbol.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
