### PR TITLE
docs(raw-rsa-keyring): Raw RSA Keyring public/private key validation

### DIFF
--- a/changes/2020-07-15_raw-rsa-keyring-public-private-key-validation/change.md
+++ b/changes/2020-07-15_raw-rsa-keyring-public-private-key-validation/change.md
@@ -51,7 +51,7 @@ Clarify language in OnEncrypt and OnDecrypt to require failure, instead of the v
 ## Out of Scope
 
 - All keyrings aside from the Raw RSA Keyring
-- The manner in which the Raw RSA Keyring is build/constructed/instantiated
+- The manner in which the Raw RSA Keyring is initialized
 - How to determine if a pair of keys match
 
 ## Motivation

--- a/changes/2020-07-15_raw-rsa-keyring-public-private-key-validation/change.md
+++ b/changes/2020-07-15_raw-rsa-keyring-public-private-key-validation/change.md
@@ -7,19 +7,17 @@
 
 This serves as a reference of all features that this change affects.
 
-| Feature |
-| ------- |
+| Feature                                                                                                                                                   |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [Raw RSA Keyring](https://github.com/awslabs/aws-encryption-sdk-specification/blob/31b0534c4259aad365f048b73231545583389c67/framework/raw-rsa-keyring.md) |
-
 
 ## Affected Specifications
 
 This serves as a reference of all specification documents that this change affects.
 
-| Specification |
-| ------------- |
+| Specification                                                                                                                                             |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [Raw RSA Keyring](https://github.com/awslabs/aws-encryption-sdk-specification/blob/31b0534c4259aad365f048b73231545583389c67/framework/raw-rsa-keyring.md) |
-
 
 ## Affected Implementations
 
@@ -33,7 +31,7 @@ This serves as a reference for all implementations that this change affects.
 ## Definitions
 
 - "match", "matching pair" describe an interoperable RSA public key, and RSA private key
- (i.e. a ciphertext encrypted by the public key can be decrypted by the private key)
+  (i.e. a ciphertext encrypted by the public key can be decrypted by the private key)
 
 ### Conventions used in this document
 

--- a/changes/2020-07-15_raw-rsa-keyring-public-private-key-validation/change.md
+++ b/changes/2020-07-15_raw-rsa-keyring-public-private-key-validation/change.md
@@ -1,0 +1,94 @@
+[//]: # "Copyright Amazon.com Inc. or its affiliates. All Rights Reserved."
+[//]: # "SPDX-License-Identifier: CC-BY-SA-4.0"
+
+# Raw RSA Keyring public/private key validation
+
+## Affected Features
+
+This serves as a reference of all features that this change affects.
+
+| Feature |
+| ------- |
+| [Raw RSA Keyring](https://github.com/awslabs/aws-encryption-sdk-specification/blob/31b0534c4259aad365f048b73231545583389c67/framework/raw-rsa-keyring.md) |
+
+
+## Affected Specifications
+
+This serves as a reference of all specification documents that this change affects.
+
+| Specification |
+| ------------- |
+| [Raw RSA Keyring](https://github.com/awslabs/aws-encryption-sdk-specification/blob/31b0534c4259aad365f048b73231545583389c67/framework/raw-rsa-keyring.md) |
+
+
+## Affected Implementations
+
+This serves as a reference for all implementations that this change affects.
+
+| Language   | Repository                                                                            |
+| ---------- | ------------------------------------------------------------------------------------- |
+| C          | [aws-encryption-sdk-c](https://github.com/aws/aws-encryption-sdk-c)                   |
+| Javascript | [aws-encryption-sdk-javascript](https://github.com/aws/aws-encryption-sdk-javascript) |
+
+## Definitions
+
+- "match", "matching pair" describe an interoperable RSA public key, and RSA private key
+ (i.e. a ciphertext encrypted by the public key can be decrypted by the private key)
+
+### Conventions used in this document
+
+The key words
+"MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+"SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL"
+in this document are to be interpreted as described in
+[RFC 2119](https://tools.ietf.org/html/rfc2119).
+
+## Summary
+
+Add a requirement to the Raw RSA Keyring that if both the public key and the private key are defined,
+they MUST form a matching pair.
+
+Clarify language in OnEncrypt and OnDecrypt to require failure, instead of the vague "MUST NOT succeed".
+
+## Out of Scope
+
+- All keyrings aside from the Raw RSA Keyring
+- The manner in which the Raw RSA Keyring is build/constructed/instantiated
+- How to determine if a pair of keys match
+
+## Motivation
+
+A Raw RSA Keyring with mismatched keys is by construction unable to fulfill its decryption contract.
+As such, we should not allow such a keyring to be constructed.
+
+Language clarification around failure is needed,
+as previous language "MUST NOT succeed" could imply a non-failure response is valid
+(such as returning encryption/decryption materials unmodified).
+
+## Drawbacks
+
+This change will break customers who are using the Raw RSA Keyring with a non-matching keypair.
+However, this is not use case we should encourage.
+
+## Security Implications
+
+This change SHOULD NOT have any security implications.
+
+## Operational Implications
+
+This change SHOULD NOT have any operational implications.
+
+## Guide-level Explanation
+
+When you attempt to create a Raw RSA Keyring with both a public and private key,
+the ESDK MUST check to ensure the keys match.
+If they keys to not match, the creation operation MUST fail.
+
+## Reference-level Explanation
+
+- A check MUST be added in the operation which creates a Raw RSA Keyring
+  - The check MUST only be run if both a public key and private key are defined
+  - The check MUST determine if the public key and private key form a matching pair
+  - If they do not form a matching pair, the operation MUST fail
+- OnEncrypt MUST fail immediately if the Raw RSA Keyring's public key is not defined
+- OnDecrypt MUST fail immediately if the Raw RSA Keyring's private key is not defined

--- a/framework/raw-aes-keyring.md
+++ b/framework/raw-aes-keyring.md
@@ -5,9 +5,13 @@
 
 ## Version
 
-0.2.0
+0.3.0
 
 ### Changelog
+
+- 0.3.0
+
+  - [Raw AES keyring MUST NOT accept a key namespace of "aws-kms".](https://github.com/awslabs/aws-encryption-sdk-specification/issues/101)
 
 - 0.2.0
 
@@ -57,6 +61,8 @@ On keyring initialization, the following inputs are REQUIRED:
 ### Key Namespace
 
 A UTF-8 encoded value that, together with the [key name](#key-name), identifies a particular [wrapping key](#wrapping-key).
+
+The raw AES keyring MUST NOT accept a key namespace of "aws-kms".
 
 This value is also used for bookkeeping purposes.
 

--- a/framework/raw-rsa-keyring.md
+++ b/framework/raw-rsa-keyring.md
@@ -5,9 +5,13 @@
 
 ## Version
 
-0.2.0
+0.3.0
 
 ### Changelog
+
+- 0.3.0
+
+  - [Raw RSA keyring MUST NOT accept a key namespace of "aws-kms".](https://github.com/awslabs/aws-encryption-sdk-specification/issues/101)
 
 - 0.2.0
 
@@ -57,9 +61,15 @@ On keyring initialization, the following inputs are REQUIRED:
 
 A UTF-8 encoded value that namespaces this keyring.
 
+The raw RSA keyring MUST NOT accept a key namespace of "aws-kms".
+
+This value is also used for bookkeeping purposes.
+
 ### Key Name
 
 A UTF-8 encoded value that names this keyring.
+
+This value is also used for bookkeeping purposes.
 
 ### Padding Scheme
 

--- a/framework/raw-rsa-keyring.md
+++ b/framework/raw-rsa-keyring.md
@@ -5,9 +5,13 @@
 
 ## Version
 
-0.3.0
+0.4.0
 
 ### Changelog
+
+- 0.4.0
+
+  - [Raw RSA Keyring public/private key validation](../changes/2020-07-15_raw-rsa-keyring-public-private-key-validation/change.md)
 
 - 0.3.0
 
@@ -56,6 +60,10 @@ On keyring initialization, the following inputs are REQUIRED:
 - [Key Name](#key-name)
 - [Padding Scheme](#padding-scheme)
 - [Public Key](#public-key) and/or [Private Key](#private-key)
+
+If both a public key and private key are provided,
+and the two keys to not form a valid key pair,
+the keyring initialization MUST fail.
 
 ### Key Namespace
 
@@ -113,7 +121,7 @@ The private key SHOULD contain all Chinese Remainder Theorem (CRT) components (p
 
 ### OnEncrypt
 
-OnEncrypt MUST NOT succeed if this keyring does not have a specified [public key](#public-key).
+OnEncrypt MUST fail if this keyring does not have a specified [public key](#public-key).
 
 OnEncrypt MUST take [encryption materials](structures.md#encryption-materials) as input.
 
@@ -139,7 +147,7 @@ If RSA encryption was successful, OnEncrypt MUST return the input
 
 ### OnDecrypt
 
-OnDecrypt MUST NOT succeed if this keyring does not have a specified [private key](#private-key).
+OnDecrypt MUST fail if this keyring does not have a specified [private key](#private-key).
 The keyring MUST NOT derive a private key from a specified [public key](#public-key)
 
 OnDecrypt MUST take [decryption materials](structures.md#decryption-materials) and


### PR DESCRIPTION
_Issue #, if available:_ resolves #91

_Description of changes:_ 

- Require a check during Raw RSA Keyring initialization if two keys are input that they form a matching key pair.
- Clarify language around behavior when OnEncrypt/OnDecrypt is called without a public key/private key respectively.

_Note:_ I went with the keyring "MUST" check that they match, instead of it "SHOULD" check that they match. This is a two-way-door, but I don't see a reason to not check.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
