### PR TITLE
docs: clarify caching CMM initialization parameters

### DIFF
--- a/changes/2020-07-15_clarify-caching-cmm-init-params/change.md
+++ b/changes/2020-07-15_clarify-caching-cmm-init-params/change.md
@@ -83,4 +83,4 @@ an [underlying CMM](../../framework/caching-cmm.md#underlying-cryptographic-mate
 or a [keyring](../../framework/keyring-interface.md).
 If the caller provides a keyring,
 then the caching CMM MUST set its underlying CMM
-to a [default CMM](../../framework/default-cmm.md) that wraps the keyring.
+to a [default CMM](../../framework/default-cmm.md) initialized with the keyring.

--- a/changes/2020-07-15_clarify-caching-cmm-init-params/change.md
+++ b/changes/2020-07-15_clarify-caching-cmm-init-params/change.md
@@ -1,0 +1,80 @@
+[//]: # "Copyright Amazon.com Inc. or its affiliates. All Rights Reserved."
+[//]: # "SPDX-License-Identifier: CC-BY-SA-4.0"
+
+# Clarify Caching Cryptographic Materials Manager Initialization Parameters
+
+## Affected Features
+
+| Feature                                                                   |
+| ------------------------------------------------------------------------- |
+| [Caching Cryptographic Materials Manager](../../framework/caching-cmm.md) |
+
+## Affected Specifications
+
+| Specification                                                             |
+| ------------------------------------------------------------------------- |
+| [Caching Cryptographic Materials Manager](../../framework/caching-cmm.md) |
+
+## Affected Implementations
+
+| Language   | Repository                                                                            |
+| ---------- | ------------------------------------------------------------------------------------- |
+| C          | [aws-encryption-sdk-c](https://github.com/aws/aws-encryption-sdk-c)                   |
+| Java       | [aws-encryption-sdk-java](https://github.com/aws/aws-encryption-sdk-java)             |
+| JavaScript | [aws-encryption-sdk-javascript](https://github.com/aws/aws-encryption-sdk-javascript) |
+| Python     | [aws-encryption-sdk-python](https://github.com/aws/aws-encryption-sdk-python)         |
+
+## Definitions
+
+### Conventions used in this document
+
+The key words
+"MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+"SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL"
+in this document are to be interpreted as described in
+[RFC 2119](https://tools.ietf.org/html/rfc2119).
+
+## Summary
+
+Upon initialization,
+the [caching Cryptographic Materials Manager (caching CMM)](../../framework/caching-cmm.md) MUST define
+an underlying CMM,
+an underlying Cryptographic Materials Cache (CMC),
+and a [time-to-live (TTL)](../../framework/caching-cmm.md) for cache entries.
+This change clarifies that the caller MUST provide these parameters.
+
+## Out of Scope
+
+- Changing the shape of any CMC APIs is out of scope.
+- Changing the shape of the CMM interface is out of scope.
+
+## Motivation
+
+Before this change,
+the [caching CMM](../../framework/caching-cmm.md) specification
+lists several properties that the caching CMM MUST define upon initialization.
+Among these,
+we intend for the caller to provide
+the [underlying CMC](../../framework/caching-cmm.md#underlying-cryptographic-materials-cache),
+the [underlying CMM](../../framework/caching-cmm.md#underlying-cryptographic-materials-manager),
+and the [TTL](../../framework/caching-cmm.md#cache-limit-ttl);
+but the specification does not state that intent.
+This change adds this missing intent.
+
+## Security Implications
+
+This change SHOULD NOT have any security implications.
+
+## Operational Implications
+
+This change can potentially break any customer using an AWS Encryption SDK implementation
+that does not require the user to provide the TTL value upon caching CMM initialization.
+However, all existing implementations require the user to provide the TTL value,
+so in practice this is not an issue.
+
+## Guide- and Reference-level Explanation
+
+When initializing a caching CMM, the caller MUST provide
+an [underlying CMC](../../framework/caching-cmm.md#underlying-cryptographic-materials-cache),
+an [underlying CMM](../../framework/caching-cmm.md#underlying-cryptographic-materials-manager),
+and a [TTL](../../framework/caching-cmm.md#cache-limit-ttl).

--- a/changes/2020-07-15_clarify-caching-cmm-init-params/change.md
+++ b/changes/2020-07-15_clarify-caching-cmm-init-params/change.md
@@ -75,6 +75,12 @@ so in practice this is not an issue.
 ## Guide- and Reference-level Explanation
 
 When initializing a caching CMM, the caller MUST provide
-an [underlying CMC](../../framework/caching-cmm.md#underlying-cryptographic-materials-cache),
-an [underlying CMM](../../framework/caching-cmm.md#underlying-cryptographic-materials-manager),
+an [underlying CMC](../../framework/caching-cmm.md#underlying-cryptographic-materials-cache)
 and a [TTL](../../framework/caching-cmm.md#cache-limit-ttl).
+
+The caller MUST either provide
+an [underlying CMM](../../framework/caching-cmm.md#underlying-cryptographic-materials-manager)
+or a [keyring](../../framework/keyring-interface.md).
+If the caller provides a keyring,
+then the caching CMM MUST set its underlying CMM
+to a [default CMM](../../framework/default-cmm.md) that wraps the keyring.

--- a/framework/caching-cmm.md
+++ b/framework/caching-cmm.md
@@ -5,15 +5,24 @@
 
 ## Version
 
-0.1.0-preview
+0.2.0
+
+### Changelog
+
+- 0.2.0
+  - [Clarify Caching Cryptographic Materials Manager Initialization Parameters](../changes/2020-07-15_clarify-caching-cmm-init-params/change.md)
+- 0.1.0-preview
+  - Initial record
 
 ## Implementations
 
-- [C](https://github.com/aws/aws-encryption-sdk-c/blob/master/include/aws/cryptosdk/cache.h)
-- [Python](https://github.com/aws/aws-encryption-sdk-python/blob/master/src/aws_encryption_sdk/materials_managers/caching.py)
-- [Java](https://github.com/aws/aws-encryption-sdk-java/blob/master/src/main/java/com/amazonaws/encryptionsdk/caching/CachingCryptoMaterialsManager.java)
-- [NodeJS](https://github.com/awslabs/aws-encryption-sdk-javascript/blob/master/modules/caching-materials-manager-node/src/caching_materials_manager_node.ts)
-- [Browser JS](https://github.com/awslabs/aws-encryption-sdk-javascript/blob/master/modules/caching-materials-manager-browser/src/caching_materials_manager_browser.ts)
+| Language   | Confirmed Compatible with Spec Version | Minimum Version Confirmed | Implementation                                                                                                                                                                                  |
+| ---------- | -------------------------------------- | ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| C          | 0.2.0                                  | 0.1.0                     | [cache.h](https://github.com/aws/aws-encryption-sdk-c/blob/master/include/aws/cryptosdk/cache.h)                                                                                                |
+| NodeJS     | 0.2.0                                  | 0.1.0                     | [caching_materials_manager_node.ts](https://github.com/awslabs/aws-encryption-sdk-javascript/blob/master/modules/caching-materials-manager-node/src/caching_materials_manager_node.ts)          |
+| Browser JS | 0.2.0                                  | 0.1.0                     | [caching_materials_manager_browser.ts](https://github.com/awslabs/aws-encryption-sdk-javascript/blob/master/modules/caching-materials-manager-browser/src/caching_materials_manager_browser.ts) |
+| Python     | 0.2.0                                  | 1.3.0                     | [materials_managers/caching.py](https://github.com/aws/aws-encryption-sdk-python/blob/master/src/aws_encryption_sdk/materials_managers/caching.py)                                              |
+| Java       | 0.2.0                                  | 1.3.0                     | [CachingCryptoMaterialsManager.java](https://github.com/aws/aws-encryption-sdk-java/blob/master/src/main/java/com/amazonaws/encryptionsdk/caching/CachingCryptoMaterialsManager.java)           |
 
 ## Overview
 
@@ -30,11 +39,15 @@ in this document are to be interpreted as described in [RFC 2119](https://tools.
 
 ## Initialization
 
-On caching CMM initialization, a caching CMM MUST define the following:
+On caching CMM initialization,
+the caller MUST provide the following values:
 
 - [Underlying Cryptographic Materials Cache (CMC)](#underlying-cryptographic-materials-cache)
 - [Underlying Cryptographic Materials Manager (CMM)](#underlying-cryptographic-materials-manager)
 - [Cache Limit TTL](#cache-limit-ttl)
+
+Additionally, the caching CMM MUST define the following:
+
 - [Partition ID](#partition-id)
 - [Limit Bytes](#limit-bytes)
 - [Limit Messages](#limit-messages)

--- a/framework/caching-cmm.md
+++ b/framework/caching-cmm.md
@@ -46,7 +46,7 @@ the caller MUST provide the following values:
 - [Underlying Cryptographic Materials Manager (CMM)](#underlying-cryptographic-materials-manager)
 - [Cache Limit TTL](#cache-limit-ttl)
 
-Additionally, the caching CMM MUST define the following:
+Additionally, the caching CMM MUST optionally accept the following:
 
 - [Partition ID](#partition-id)
 - [Limit Bytes](#limit-bytes)

--- a/framework/caching-cmm.md
+++ b/framework/caching-cmm.md
@@ -43,10 +43,18 @@ On caching CMM initialization,
 the caller MUST provide the following values:
 
 - [Underlying Cryptographic Materials Cache (CMC)](#underlying-cryptographic-materials-cache)
-- [Underlying Cryptographic Materials Manager (CMM)](#underlying-cryptographic-materials-manager)
 - [Cache Limit TTL](#cache-limit-ttl)
 
-Additionally, the caching CMM MUST optionally accept the following:
+Additionally, the caller MUST provide one of the following values:
+
+- [Underlying Cryptographic Materials Manager (CMM)](#underlying-cryptographic-materials-manager)
+- [Keyring](keyring-interface.md)
+
+If the caller provides a keyring,
+then the caching CMM MUST set its underlying CMM
+to a [default CMM](../../framework/default-cmm.md) that wraps the keyring.
+
+Finally, the caching CMM MUST optionally accept the following values:
 
 - [Partition ID](#partition-id)
 - [Limit Bytes](#limit-bytes)

--- a/framework/caching-cmm.md
+++ b/framework/caching-cmm.md
@@ -52,7 +52,7 @@ Additionally, the caller MUST provide one of the following values:
 
 If the caller provides a keyring,
 then the caching CMM MUST set its underlying CMM
-to a [default CMM](../../framework/default-cmm.md) that wraps the keyring.
+to a [default CMM](../../framework/default-cmm.md) initialized with the keyring.
 
 Finally, the caching CMM MUST optionally accept the following values:
 


### PR DESCRIPTION
_Issue #, if available:_ #79 

_Description of changes:_
> Upon initialization, the caching Cryptographic Materials Manager (caching CMM) MUST define an underlying CMM, an underlying Cryptographic Materials Cache (CMC), and a time-to-live (TTL) for cache entries. This change clarifies that the caller MUST provide these parameters.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
