### PR TITLE
docs: return nothing from Put Cache Entry in CMC

### DIFF
--- a/changes/2020-07-20_put-cache-entry-returns-nothing/change.md
+++ b/changes/2020-07-20_put-cache-entry-returns-nothing/change.md
@@ -1,0 +1,110 @@
+[//]: # "Copyright Amazon.com Inc. or its affiliates. All Rights Reserved."
+[//]: # "SPDX-License-Identifier: CC-BY-SA-4.0"
+
+# Return Nothing from Put Cache Entry in Cryptographic Materials Cache
+
+## Affected Features
+
+| Feature                                                                                     |
+| ------------------------------------------------------------------------------------------- |
+| [Cryptographic Materials Cache Interface](../../framework/cryptographic-materials-cache.md) |
+
+## Affected Specifications
+
+| Specification                                                                               |
+| ------------------------------------------------------------------------------------------- |
+| [Cryptographic Materials Cache Interface](../../framework/cryptographic-materials-cache.md) |
+
+## Affected Implementations
+
+| Language | Repository                                                                    |
+| -------- | ----------------------------------------------------------------------------- |
+| Java     | [aws-encryption-sdk-java](https://github.com/aws/aws-encryption-sdk-java)     |
+| Python   | [aws-encryption-sdk-python](https://github.com/aws/aws-encryption-sdk-python) |
+
+## Definitions
+
+### Conventions used in this document
+
+The key words
+"MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+"SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL"
+in this document are to be interpreted as described in
+[RFC 2119](https://tools.ietf.org/html/rfc2119).
+
+## Summary
+
+The [Cryptographic Materials Cache (CMC)](../../framework/cryptographic-materials-cache.md) specification
+does not specify whether or not the Put Cache Entry operation
+returns the cache entry that it inserts.
+Some implementations do and others do not.
+This change specifiies that the Put Cache Entry operation
+MUST NOT return the cache entry that it inserts.
+
+## Out of Scope
+
+- Changing the shape of the caching CMM operations is out of scope.
+
+## Motivation
+
+The [Cryptographic Materials Cache (CMC)](../../framework/cryptographic-materials-cache.md) specification
+does not specify whether or not the Put Cache Entry operation
+returns the cache entry that it inserts.
+Noting that the only user of the CMC is the
+[caching Cryptographic Materials Manager](../../framework/caching-cmm.md),
+we suppose that the operation does return the inserted entry
+and examine what the caching CMM might do with it.
+
+The caching CMM acquires cryptographic materials
+from an underlying CMM before placing them in the CMC
+via the Put Cache Entry operation.
+It also provides usage metadata to the operation
+so that the CMC can attach the metadata to the cache entry
+before storing the entry.
+But in the interest of separating concerns,
+the CMC does not include any other data in the cache entry,
+so the inserted cache entry ultimately contains only
+data that was originally provided by the caching CMM.
+It follows that the caching CMM has no reason
+to _read_ the inserted cache entry if the entry were returned.
+
+Furthermore,
+the caching CMM aims to provide only atomic operations,
+which necessitates that it reads and modifies the CMC state atomically.
+Suppose the caching CMM were to place materials in the CMC
+via the Put Cache Entry operation,
+receive the inserted entry via return value,
+and then modify the entry
+before returning the cryptographic materials to its caller.
+On the one hand,
+it is unsafe for the caching CMM to return the materials
+without writing the modified entry back to the CMC.
+On the other hand,
+it is not atomic if the caching does write the modified entry back to the CMC.
+It follows that the caching CMM has no safe way
+to _write_ to the inserted cache entry if the entry were returned,
+and so it has no good reason to.
+
+The caching CMM has reason
+neither to read nor write to a returned cache entry,
+so we conclude that the operation MUST NOT return the inserted cache entry.
+
+Indeed,
+the caching CMM ignores the operation's return value
+in every existing implementation
+where the operation returns the inserted cache entry
+(namely, the Java and Python implementations).
+This solidifies our view that the return value is unnecessary.
+
+## Security Implications
+
+This change SHOULD NOT have any security implications.
+
+## Operational Implications
+
+We MUST change the Java and Python implementations of Put Cache Entry
+do not return the inserted cache entry.
+
+## Guide-level and Reference-level Explanation
+
+The Put Cache Entry operation MUST NOT return the inserted cache entry.

--- a/changes/2020-07-20_put-cache-entry-returns-nothing/change.md
+++ b/changes/2020-07-20_put-cache-entry-returns-nothing/change.md
@@ -103,7 +103,7 @@ This change SHOULD NOT have any security implications.
 ## Operational Implications
 
 We MUST change the Java and Python implementations of Put Cache Entry
-do not return the inserted cache entry.
+to not return the inserted cache entry.
 
 ## Guide-level and Reference-level Explanation
 

--- a/changes/2020-07-20_put-cache-entry-returns-nothing/change.md
+++ b/changes/2020-07-20_put-cache-entry-returns-nothing/change.md
@@ -38,7 +38,7 @@ The [Cryptographic Materials Cache (CMC)](../../framework/cryptographic-material
 does not specify whether or not the Put Cache Entry operation
 returns the cache entry that it inserts.
 Some implementations do and others do not.
-This change specifiies that the Put Cache Entry operation
+This change specifies that the Put Cache Entry operation
 MUST NOT return the cache entry that it inserts.
 
 ## Out of Scope

--- a/framework/cryptographic-materials-cache.md
+++ b/framework/cryptographic-materials-cache.md
@@ -5,8 +5,12 @@
 
 ## Version
 
+0.3.0
+
 ### Changelog
 
+- 0.3.0
+  - [Return Nothing from Put Cache Entry in Cryptographic Materials Cache](../changes/2020-07-20_put-cache-entry-returns-nothing/change.md)
 - 0.2.0
   - [Refactor Cryptographic Materials Cache Specification](../changes/2020-07-14_refactor-cmc-spec/change.md)
 - 0.1.0-preview
@@ -88,6 +92,7 @@ The Cryptographic Materials Cache provides behaviours for putting cache entry, g
 
 Attempts to put a cache entry for the specified cache ID.
 If a cache entry for the given Cache ID does not exists in the cache, the CMC creates a new cache entry.
+This operation MUST NOT return the inserted cache entry.
 
 ### Get Cache Entry
 


### PR DESCRIPTION
_Issue #, if available:_ #2 

_Description of changes:_
> The Cryptographic Materials Cache (CMC) specification does not specify whether or not the Put Cache Entry operation returns the cache entry that it inserts. Some implementations do and others do not. This change specifies that the Put Cache Entry operation MUST NOT return the cache entry that it inserts.

Closes #2.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
