### PR TITLE
fix: apply consistent behavior for refusing to write or fullfil any decryption contract

### DIFF
--- a/changes/2020-06-04_how-to-fail-with-keyrings/change.md
+++ b/changes/2020-06-04_how-to-fail-with-keyrings/change.md
@@ -18,6 +18,9 @@ This serves as a reference of all specification documents that this change affec
 | Specification                                             |
 | --------------------------------------------------------- |
 | [Keyring Interface](../../framework/keyring-interface.md) |
+| [Raw AES Keyring](../../framework/raw-aes-keyring.md)     |
+| [Raw RSA Keyring](../../framework/raw-rsa-keyring.md)     |
+| [Multi-Keyring](../../framework/multi-keyring.md)         |
 
 ## Affected Implementations
 

--- a/framework/keyring-interface.md
+++ b/framework/keyring-interface.md
@@ -5,9 +5,14 @@
 
 ## Version
 
-0.2.2
+0.2.3
 
 ### Changelog
+
+- 0.2.3
+
+  - Fix stated behavior if doing nothing
+    as defined in [how to fail](../changes/2020-06-04_how-to-fail-with-keyrings/change.md).
 
 - 0.2.2
 
@@ -106,8 +111,8 @@ and MAY modify it with any of the following behaviors:
 If this keyring attempted any of the above behaviors, and successfully completed those behaviors,
 it MUST output the modified [encryption materials](structures.md#encryption-materials).
 
-If the keyring did not attempt any of the above behaviors, it MUST output the
-[encryption materials](structures.md#encryption-materials) unmodified.
+If the keyring did not attempt any of the above behaviors, it MUST fail
+and it MUST NOT modify the [encryption materials](structures.md#encryption-materials).
 
 #### Generate Data Key
 
@@ -159,7 +164,8 @@ MAY modify it with the following behavior:
 If this keyring attempted the above behavior, and succeeded, it MUST output the modified [decryption materials](structures.md#decryption-materials).
 
 If the keyring did not attempt the above behavior,
-the keyring MUST output the [decryption materials](structures.md#decryption-materials) unmodified.
+the keyring MUST fail
+and MUST NOT modify the [decryption materials](structures.md#decryption-materials).
 
 #### Decrypt Data Key
 

--- a/framework/keyring-interface.md
+++ b/framework/keyring-interface.md
@@ -113,8 +113,6 @@ it MUST output the modified [encryption materials](structures.md#encryption-mate
 
 If the keyring did not attempt any of the above behaviors, it MUST fail
 and it MUST NOT modify the [encryption materials](structures.md#encryption-materials).
-In failing, it MUST provide the failure message
-`No action taken by keyring on encrypt.`
 
 #### Generate Data Key
 
@@ -163,13 +161,15 @@ MAY modify it with the following behavior:
 
 - [Decrypt data key](#decrypt-data-key)
 
+If the decryption materials already contain a plaintext data key,
+the keyring MUST fail
+and MUST NOT modify the [decryption materials](structures.md#decryption-materials).
+
 If this keyring attempted the above behavior, and succeeded, it MUST output the modified [decryption materials](structures.md#decryption-materials).
 
 If the keyring did not attempt the above behavior,
 the keyring MUST fail
 and MUST NOT modify the [decryption materials](structures.md#decryption-materials).
-In failing, it MUST provide the failure message
-`No action take by keyring on decrypt.`
 
 #### Decrypt Data Key
 

--- a/framework/keyring-interface.md
+++ b/framework/keyring-interface.md
@@ -113,6 +113,8 @@ it MUST output the modified [encryption materials](structures.md#encryption-mate
 
 If the keyring did not attempt any of the above behaviors, it MUST fail
 and it MUST NOT modify the [encryption materials](structures.md#encryption-materials).
+In failing, it MUST provide the failure message
+`No action taken by keyring on encrypt.`
 
 #### Generate Data Key
 
@@ -166,6 +168,8 @@ If this keyring attempted the above behavior, and succeeded, it MUST output the 
 If the keyring did not attempt the above behavior,
 the keyring MUST fail
 and MUST NOT modify the [decryption materials](structures.md#decryption-materials).
+In failing, it MUST provide the failure message
+`No action take by keyring on decrypt.`
 
 #### Decrypt Data Key
 

--- a/framework/keyring-interface.md
+++ b/framework/keyring-interface.md
@@ -11,8 +11,8 @@
 
 - 0.2.3
 
-  - Fix stated behavior if doing nothing
-    as defined in [how to fail](../changes/2020-06-04_how-to-fail-with-keyrings/change.md).
+  - Fix stated behavior if the keyring takes no action
+    to conform with [how to fail](../changes/2020-06-04_how-to-fail-with-keyrings/change.md).
 
 - 0.2.2
 

--- a/framework/multi-keyring.md
+++ b/framework/multi-keyring.md
@@ -5,7 +5,17 @@
 
 ## Version
 
-0.1.0-preview
+0.1.1
+
+## Changelog
+
+- 0.1.1
+
+  - Clarify [keyring failure on decrypt](../changes/2020-06-04_how-to-fail-with-keyrings/change.md)
+
+- 0.1.0-preview
+
+  - Initial record
 
 ## Implementations
 
@@ -90,8 +100,9 @@ the [encryption materials](structures.md#encryption-materials) returned by the l
 
 ### OnDecrypt
 
-If the input [decryption materials](structures.md#decryption-materials) contains a plaintext data key,
-OnDecrypt MUST immediately return the unmodified decryption materials.
+If the decryption materials already contain a plaintext data key,
+the keyring MUST fail
+and MUST NOT modify the [decryption materials](structures.md#decryption-materials).
 
 Otherwise, OnDecrypt MUST attempt to decrypt the [encrypted data keys](structures.md#encrypted-data-keys-1)
 in the input [decryption materials](structures.md#decryption-materials) using its

--- a/framework/raw-aes-keyring.md
+++ b/framework/raw-aes-keyring.md
@@ -207,4 +207,6 @@ If decrypting, the keyring MUST use AES-GCM with the following specifics:
 If a decryption succeeds, this keyring MUST
 add the resulting plaintext data key to the decryption materials and return the modified materials.
 
-If no decryption succeeds, the decryption MUST NOT make any update to the decryption materials and MUST fail.
+If no decryption succeeds,
+the keyring MUST fail
+and MUST NOT modify the [decryption materials](structures.md#decryption-materials).

--- a/framework/raw-aes-keyring.md
+++ b/framework/raw-aes-keyring.md
@@ -5,9 +5,13 @@
 
 ## Version
 
-0.4.0
+0.4.1
 
 ### Changelog
+
+- 0.4.1
+
+  - Clarify [keyring failure on decrypt](../changes/2020-06-04_how-to-fail-with-keyrings/change.md)
 
 - 0.4.0
 
@@ -173,6 +177,10 @@ OnEncrypt MUST output the modified [encryption materials](structures.md#encrypti
 
 OnDecrypt MUST take [decryption materials](structures.md#decryption-materials) and
 a list of [encrypted data keys](structures.md#encrypted-data-key) as input.
+
+If the decryption materials already contain a plaintext data key,
+the keyring MUST fail
+and MUST NOT modify the [decryption materials](structures.md#decryption-materials).
 
 The keyring MUST attempt to serialize the [decryption materials'](structures.md#decryption-materials)
 [encryption context](structures.md#encryption-context-1) in the same format

--- a/framework/raw-rsa-keyring.md
+++ b/framework/raw-rsa-keyring.md
@@ -5,9 +5,13 @@
 
 ## Version
 
-0.3.1
+0.3.2
 
 ### Changelog
+
+- 0.3.2
+
+  - Clarify [keyring failure on decrypt](../changes/2020-06-04_how-to-fail-with-keyrings/change.md)
 
 - 0.3.1
 
@@ -135,6 +139,10 @@ OnDecrypt MUST fail if this keyring does not have a specified [private key](#pri
 
 OnDecrypt MUST take [decryption materials](structures.md#decryption-materials) and
 a list of [encrypted data keys](structures.md#encrypted-data-key) as input.
+
+If the decryption materials already contain a plaintext data key,
+the keyring MUST fail
+and MUST NOT modify the [decryption materials](structures.md#decryption-materials).
 
 The keyring MUST attempt to decrypt the input encrypted data keys, in list order, until it successfully decrypts one.
 

--- a/framework/raw-rsa-keyring.md
+++ b/framework/raw-rsa-keyring.md
@@ -105,7 +105,7 @@ The private key SHOULD contain all Chinese Remainder Theorem (CRT) components (p
 ### OnEncrypt
 
 OnEncrypt MUST fail if this keyring does not have a specified [public key](#public-key).
-The keyring MUST NOT derive a public key from a specified [private key](#private-key)
+The keyring MUST NOT derive a public key from a specified [private key](#private-key).
 
 OnEncrypt MUST take [encryption materials](structures.md#encryption-materials) as input.
 
@@ -157,4 +157,6 @@ If any decryption succeeds, this keyring MUST immediately return the input
 
 - The output of RSA decryption is set as the decryption material's plaintext data key.
 
-If no decryption succeeds, this keyring MUST NOT make any update to the decryption materials and MUST fail.
+If no decryption succeeds,
+the keyring MUST fail
+and MUST NOT modify the [decryption materials](structures.md#decryption-materials).


### PR DESCRIPTION
_Issue #, if available:_

These are changes I missed making when defining decryption contracts and keyring failure modes. Now that no-ops are not allowed, if a keyring would have previously been a no-op, it MUST now fail.

_Description of changes:_

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
