### PR TITLE
chore: clarify wording for CMM algorithm suites

### DIFF
--- a/framework/caching-cmm.md
+++ b/framework/caching-cmm.md
@@ -135,7 +135,8 @@ The number of bytes encrypted by the [encryption](structures.md#encryption-mater
 
 ### Get Encryption Materials
 
-If the [algorithm suite](algorithm-suites.md) requested contains a [Identity KDF](algorithm-suites.md#identity-kdf),
+If the [algorithm suite](algorithm-suites.md) is present in the encryption materials request,
+and it contains an [Identity KDF](algorithm-suites.md#identity-kdf),
 the caching CMM MUST obtain the encryption materials by making a call to the underlying CMM's [Get Encryption Materials](cmm-interface.md#get-encryption-materials) function.
 
 Otherwise, the caching CMM MUST attempt to find the [encryption materials](structures.md#encryption-materials)
@@ -147,10 +148,12 @@ If a cache entry is found, the caching CMM MUST return the encryption materials 
 If a cache entry is not found or the cache entry is expired, the caching CMM MUST then attempt to obtain the encryption materials
 by making a call to the underlying CMM's [Get Encryption Materials](cmm-interface.md#get-encryption-materials).
 
-If the [algorithm suite](algorithm-suites.md) requested does not contain an [Identity KDF](algorithm-suites.md#identity-kdf),
+If the [algorithm suite](algorithm-suites.md) is present in the encryption materials request,
+and it does not contain an [Identity KDF](algorithm-suites.md#identity-kdf),
 the caching CMM MUST add the encryption materials obtained from the underlying CMM into the underlying CMC.
 
-If the [algorithm suite](algorithm-suites.md) requested contains an Identity KDF,
+If the [algorithm suite](algorithm-suites.md) is present in the encryption materials request,
+and it contains an Identity KDF,
 the caching CMM MUST NOT store the encryption materials in the underlying CMC.
 
 ### Decrypt Materials

--- a/framework/cmm-interface.md
+++ b/framework/cmm-interface.md
@@ -106,9 +106,9 @@ The encryption materials returned MUST include the following:
 - [Encryption Context](structures.md#encryption-context)
   - The CMM MAY modify the encryption context.
 
-If the algorithm suite contains a [signing algorithm](algorithm-suites.md#signature-algorithm):
-
-- The CMM MUST include a [signing key](structures.md#signing-key).
+If the algorithm suite is present in the encryption materials request,
+and it contains a [signing algorithm](algorithm-suites.md#signature-algorithm),
+then the encryption materials returned MUST include a [signing key](structures.md#signing-key).
 
 The CMM MUST ensure that the encryption materials returned are valid.
 
@@ -116,7 +116,9 @@ The CMM MUST ensure that the encryption materials returned are valid.
 - The value of the plaintext data key MUST be non-NULL.
 - The plaintext data key length MUST be equal to the [key derivation input length](algorithm-suites.md#key-derivation-input-length).
 - The encrypted data keys list MUST contain at least one encrypted data key.
-- If the algorithm suite contains a signing algorithm, the encryption materials returned MUST include the generated signing key.
+- If the algorithm suite is present in the encryption materials request,
+  and it contains a signing algorithm,
+  then the encryption materials returned MUST include the generated signing key.
 
 #### Decrypt Materials
 
@@ -130,7 +132,7 @@ The decryption materials returned MUST include the following:
   - The CMM MAY modify the encryption context.
   - The operations made on the encryption context on the Get Encryption Materials call SHOULD be inverted on the Decrypt Materials call.
 - [Algorithm Suite](algorithm-suites.md)
-  - If the decrypt materials request contains an algorithm suite, the decryption materials returned SHOULD contain the same algorithm suite.
+  - The decryption materials returned SHOULD contain the same algorithm suite as the decrypt materials request.
 
 If the algorithm suite obtained from the decryption request contains a [signing algorithm](algorithm-suites.md#signature-algorithm),
 the decryption materials MUST include the [signature verification key](structures.md#verification-key).


### PR DESCRIPTION
_Issue #, if available:_ N/A

_Description of changes:_
In the CMM interface, the algorithm suite is optional in the Encryption Materials request and mandatory in the Decrypt Materials request. This PR clarifies that specification statements about the algorithm suite apply only if the algorithm suite is present (in the Encryption Materials case), and that such statements are unconditional when the algorithm suite is mandatory (i.e. in the Decrypt Materials case).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
