### PR TITLE
fix: Java linter interaction with test_conditions

### DIFF
--- a/util/test_conditions
+++ b/util/test_conditions
@@ -31,7 +31,7 @@ const fileSettings = {
     complianceConfig: standardComplianceParams,
   },
   ".java:": {
-    conditionRemove: /(\*\/)|(\/\*)|(@DisplayName\(\")|(\"\))/g,
+    conditionRemove: /(\*\/)|(\/\*)|(@DisplayName\(\")|(\"\))|(\")|(\"\))/g,
     complianceConfig: standardComplianceParams,
   },
   ".py:": {

--- a/util/test_conditions
+++ b/util/test_conditions
@@ -31,7 +31,7 @@ const fileSettings = {
     complianceConfig: standardComplianceParams,
   },
   ".java:": {
-    conditionRemove: /(\*\/)|(\/\*)|(@DisplayName\(\")|(\"\))|(\")|(\"\))/g,
+    conditionRemove: /(\*\/)|(\/\*)|(@DisplayName\(\")|(\"\))|(\")/g,
     complianceConfig: standardComplianceParams,
   },
   ".py:": {


### PR DESCRIPTION
If the linter moves the test `DisplayName`
to a new line because of the line length,
the condition should not break.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
