### PR TITLE
Adjust link to point to `algorithm-suites` instead of `algorithm-suite`

### DIFF
--- a/client-apis/encrypt.md
+++ b/client-apis/encrypt.md
@@ -90,7 +90,7 @@ A Keyring that implements the [keyring interface](../framework/keyring-interface
 
 ### Algorithm Suite
 
-The [algorithm suite](../framework/algorithm-suite.md) that SHOULD be used for encryption.
+The [algorithm suite](../framework/algorithm-suites.md) that SHOULD be used for encryption.
 
 ### Frame Length
 


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
The current link is pointing to a location that doesn't exist (resulting in a 404). The commit fixes the link to a known location for the algorithm suites.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
