### PR TITLE
docs: link to private-Duvet issue in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ run `./ci/prettify.sh check`.
 
 ## Generate Duvet Reports
 
-[Duvet](https://github.com/awslabs/duvet) is a tool that can be used to ensure specification is documented alongside code.
+[Duvet](https://github.com/awslabs/aws-encryption-sdk-specification/issues/240) is a tool that can be used to ensure specification is documented alongside code.
 
 This repo contains helpful scripts for installing and using Duvet with this specification.
 


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_ Replaces the link to the private Duvet repo with a link to the tracking issue for making Duvet public.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
