### PR TITLE
chore: add files-moved check to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,3 +3,7 @@ _Issue #, if available:_
 _Description of changes:_
 
 By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
+
+
+# Check any applicable:
+- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,6 @@ _Description of changes:_
 
 By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
 
-
 # Check any applicable:
+
 - [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_ Adds a "files moved?" checkbox to the PR template, as we have in our other repos (e.g. [aws-encryption-sdk-java](https://github.com/aws/aws-encryption-sdk-java/blob/master/.github/PULL_REQUEST_TEMPLATE.md)).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
