### PR TITLE
chore: update keyring interface to reflect KMS keyring changes

### DIFF
--- a/framework/keyring-interface.md
+++ b/framework/keyring-interface.md
@@ -215,7 +215,7 @@ the decryption is overwhelmingly likely to fail.
 Users SHOULD use a keyring that protects wrapping keys and performs cryptographic operations within a secure boundary.
 Examples are:
 
-- The built-in [AWS KMS keyrings](./aws-kms),
+- The built-in [AWS KMS keyrings](./aws-kms/),
   which use AWS Key Management Service (AWS KMS) customer master keys (CMKs) that never leave AWS KMS as plaintext.
 - A custom keyring that uses wrapping keys that are stored in your hardware security modules (HSMs)
 - A custom keyring protected by another master key service.
@@ -230,11 +230,11 @@ however users should refer to their specification for notes on their respective 
 The following keyrings are compatible with the referenced [master key providers](master-key-provider-interface.md) or
 [master keys](master-key-interface.md) when configured to use the same wrapping key.
 
-| Keyring         | Master Key Provider: Java and Python                                                                             |
-| --------------- | ---------------------------------------------------------------------------------------------------------------- |
+| Keyring          | Master Key Provider: Java and Python                                                                             |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------- |
 | AWS KMS keyrings | KMS master key (Java), KMS master key provider (Java), KMS master key (Python), KMS master key provider (Python) |
-| Raw AES keyring | When they are used with symmetric encryption keys: JceMasterKey (Java), RawMasterKey (Python)                    |
-| Raw RSA keyring | When they are used with asymmetric encryption keys: JceMasterKey (Java), RawMasterKey (Python)                   |
+| Raw AES keyring  | When they are used with symmetric encryption keys: JceMasterKey (Java), RawMasterKey (Python)                    |
+| Raw RSA keyring  | When they are used with asymmetric encryption keys: JceMasterKey (Java), RawMasterKey (Python)                   |
 
 ### Why should I use Keyrings instead of Master Key Providers and Master Keys?
 

--- a/framework/keyring-interface.md
+++ b/framework/keyring-interface.md
@@ -11,7 +11,7 @@
 
 - 0.2.4
 
-  - Fix broken links to AWS KMS Keyrings
+  - Update list of AWS KMS Keyrings
 
 - 0.2.3
 
@@ -98,6 +98,14 @@ and SHOULD be equal to a UTF-8 encoding of the key name.
 ## Supported Keyrings
 
 - [AWS KMS Keyrings](./aws-kms/)
+  - [AWS KMS Keyring](./aws-kms/aws-kms-keyring.md)
+  - [AWS KMS RSA Keyring](./aws-kms/aws-kms-rsa-keyring.md)
+  - [AWS KMS Multi Keyrings](./aws-kms/aws-kms-multi-keyrings.md)
+  - [AWS KMS Discovery Keyring](./aws-kms/aws-kms-discovery-keyring.md)
+  - [AWS KMS MRK Discovery Keyring](./aws-kms/aws-kms-mrk-discovery-keyring.md)
+  - [AWS KMS MRK Keyring](./aws-kms/aws-kms-mrk-keyring.md)
+  - [AWS KMS MRK Multi Keyrings](./aws-kms/aws-kms-mrk-multi-keyrings.md)
+  - [AWS KMS Hierarchical Keyring](./aws-kms/aws-kms-hierarchical-keyring.md)
 - [Multi-Keyring](multi-keyring.md)
 - [Raw AES Keyring](raw-aes-keyring.md)
 - [Raw RSA Keyring](raw-rsa-keyring.md)

--- a/framework/keyring-interface.md
+++ b/framework/keyring-interface.md
@@ -82,7 +82,7 @@ for a keyring that can fulfill this decryption contract.
 The key provider ID MUST be a binary value
 and SHOULD be equal to a UTF-8 encoding of the key namespace.
 
-This value MUST NOT be "aws-kms"
+This value MUST NOT be or start with "aws-kms"
 unless this encrypted data key was produced by one of the [AWS KMS Keyrings](./aws-kms/).
 
 ### key provider info

--- a/framework/keyring-interface.md
+++ b/framework/keyring-interface.md
@@ -5,9 +5,13 @@
 
 ## Version
 
-0.2.3
+0.2.4
 
 ### Changelog
+
+- 0.2.4
+
+  - Fix broken links to AWS KMS Keyrings
 
 - 0.2.3
 
@@ -79,7 +83,7 @@ The key provider ID MUST be a binary value
 and SHOULD be equal to a UTF-8 encoding of the key namespace.
 
 This value MUST NOT be "aws-kms"
-unless this encrypted data key was produced by the [AWS KMS Keyring](kms-keyring.md).
+unless this encrypted data key was produced by one of the [AWS KMS Keyrings](./aws-kms/).
 
 ### key provider info
 
@@ -93,7 +97,7 @@ and SHOULD be equal to a UTF-8 encoding of the key name.
 
 ## Supported Keyrings
 
-- [AWS KMS Keyring](kms-keyring.md)
+- [AWS KMS Keyrings](./aws-kms/)
 - [Multi-Keyring](multi-keyring.md)
 - [Raw AES Keyring](raw-aes-keyring.md)
 - [Raw RSA Keyring](raw-rsa-keyring.md)
@@ -211,8 +215,8 @@ the decryption is overwhelmingly likely to fail.
 Users SHOULD use a keyring that protects wrapping keys and performs cryptographic operations within a secure boundary.
 Examples are:
 
-- The built-in [AWS KMS keyring](kms-keyring.md),
-  which uses AWS Key Management Service (AWS KMS) customer master keys (CMKs) that never leave AWS KMS plaintext.
+- The built-in [AWS KMS keyrings](./aws-kms),
+  which use AWS Key Management Service (AWS KMS) customer master keys (CMKs) that never leave AWS KMS as plaintext.
 - A custom keyring that uses wrapping keys that are stored in your hardware security modules (HSMs)
 - A custom keyring protected by another master key service.
 
@@ -228,7 +232,7 @@ The following keyrings are compatible with the referenced [master key providers]
 
 | Keyring         | Master Key Provider: Java and Python                                                                             |
 | --------------- | ---------------------------------------------------------------------------------------------------------------- |
-| AWS KMS keyring | KMS master key (Java), KMS master key provider (Java), KMS master key (Python), KMS master key provider (Python) |
+| AWS KMS keyrings | KMS master key (Java), KMS master key provider (Java), KMS master key (Python), KMS master key provider (Python) |
 | Raw AES keyring | When they are used with symmetric encryption keys: JceMasterKey (Java), RawMasterKey (Python)                    |
 | Raw RSA keyring | When they are used with asymmetric encryption keys: JceMasterKey (Java), RawMasterKey (Python)                   |
 


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

Minimal updates to the `keyring-interface` specification to reflect that there are now multiple AWS KMS keyrings.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Check any applicable:

- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.
