### PR TITLE
fix: Minor fixes to Required Encryption Context CMM

### DIFF
--- a/changes/2022-11-14_encryption_context_on_decrypt/background.md
+++ b/changes/2022-11-14_encryption_context_on_decrypt/background.md
@@ -36,7 +36,8 @@ there is customer value in a more nuanced view of encryption context.
    and valuable authenticated encryption context.
 
 1. Customers should not be forced
-   to choose between leaking non-public data
+   to choose between storing non-public data
+   alongside encrypted messages
    and valuable authenticated encryption context.
 
 1. Customers should be able

--- a/changes/2022-11-14_encryption_context_on_decrypt/encryption_context_use_cases.md
+++ b/changes/2022-11-14_encryption_context_on_decrypt/encryption_context_use_cases.md
@@ -148,21 +148,26 @@ precise formulations of customer requirements.
    To protect myself from confused deputy problems
    I want to use information to identify
    the customer who owns this ciphertext.
-   This information is non-public
-   and disclosure of this information
-   could impact either the customer
-   or the security of the application as a whole.
+   This information is non-public.
+   While it is not so sensitive that it
+   must be encrypted in transit,
+   it is also not appropriate to
+   transmit this data publicly in plaintext.
 
    For example, using a customer ID
    or email address would result
-   in leaking non-public data.
+   in always sending that data
+   in plaintext as part of the
+   encrypted messages.
 
    **As an encrypter I want
    to have non-public information
    in my encryption context,
    but still store or transit
-   my ciphertext in public
-   without leaking my non-public data.**
+   my ciphertext without
+   additionally storing or transmitting
+   this non-public information
+   in plaintext.**
 
 1. Non-public is not the same as secret
 

--- a/framework/required-encryption-context-cmm.md
+++ b/framework/required-encryption-context-cmm.md
@@ -14,7 +14,7 @@
 
 ## Overview
 
-Expected Encryption Context Cryptographic Materials Manager (CMM)
+Required Encryption Context Cryptographic Materials Manager (CMM)
 is a built-in CMM to add additional controls for Encryption Context.
 
 This CMM can be configured with a set of [encryption context](./structures.md#encryption-context) keys.
@@ -34,7 +34,7 @@ in this document are to be interpreted as described in [RFC 2119](https://tools.
 
 ## Initialization
 
-On Expected Encryption Context CMM initialization,
+On Required Encryption Context CMM initialization,
 the caller MUST provide the following values:
 
 - [Required Encryption Context Keys](#required-encryption-context-keys)
@@ -45,7 +45,7 @@ Additionally, the caller MUST provide one of the following values:
 - [Keyring](keyring-interface.md)
 
 If the caller provides a keyring,
-then the Expected Encryption Context CMM MUST set its underlying CMM
+then the Required Encryption Context CMM MUST set its underlying CMM
 to a [default CMM](default-cmm.md) initialized with the keyring.
 
 ### Underlying Cryptographic Materials Manager
@@ -55,7 +55,7 @@ to query for encryption/decryption materials.
 
 ### Required Encryption Context Keys
 
-The set of encryption context keys to expect
+The set of encryption context keys to require
 in all [behaviors](#behaviors).
 
 ## Behaviors
@@ -66,7 +66,7 @@ The encryption context on the [encryption materials request](./cmm-interface.md#
 MUST contain a value for every key in the configured [required encryption context keys](#required-encryption-context-keys)
 or this request MUST fail.
 
-The Expected Encryption Context CMM MUST attempt to obtain [encryption materials](./structures.md#encryption-materials)
+The Required Encryption Context CMM MUST attempt to obtain [encryption materials](./structures.md#encryption-materials)
 by making a call to the [underlying CMM's](#underlying-cryptographic-materials-manager)
 [Get Encryption Materials](cmm-interface.md#get-encryption-materials).
 All configured [required encryption context keys](#required-encryption-context-keys)
@@ -84,7 +84,7 @@ The reproduced encryption context on the [decrypt materials request](./cmm-inter
 MUST contain a value for every key in the configured [required encryption context keys](#required-encryption-context-keys)
 or this request MUST fail.
 
-The Expected Encryption Context
+The Required Encryption Context
 CMM MUST attempt to obtain [decryption materials](./structures.md#decryption-materials)
 by making a call to the [underlying CMM's](#underlying-cryptographic-materials-manager)
 [decrypt materials](cmm-interface.md#decrypt-materials) interface


### PR DESCRIPTION
Clarify wording in `changes` in order to not imply that we are asserting that data that is sent along as AAD is protected. The importance to focus on is that customers may have data that is not sensitive, and is ok to process as AAD, but they would still prefer to not have that data stored alongside the message in readily available plaintext.

Also fix the naming in the Required Encryption Context CMM.

# Check any applicable:

- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.
