### PR TITLE
fix: Correct intermediate edk ciphertext length

### DIFF
--- a/framework/algorithm-suites.md
+++ b/framework/algorithm-suites.md
@@ -361,7 +361,7 @@ have the following requirements:
 
 | Field                      | Length (bytes)                                     | Interpreted as |
 | -------------------------- | -------------------------------------------------- | -------------- |
-| Wrapped Plaintext Data Key | The algorithm suite's encryption key length + 12   | Bytes          |
+| Wrapped Plaintext Data Key | The algorithm suite's encryption key length + 16   | Bytes          |
 | Wrapped Intermediate Key   | Determined by the keyring responsible for wrapping | Bytes          |
 
 ##### Wrapped Plaintext Data Key


### PR DESCRIPTION
This was "fixed" in the duvet annotation in the MPL, but not fixed in the original specification.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.