### PR TITLE
feat: Key store storage option

### DIFF
--- a/changes/2024-6-17_key-store-persistance/background.md
+++ b/changes/2024-6-17_key-store-persistance/background.md
@@ -1,0 +1,355 @@
+[//]: # "Copyright Amazon.com Inc. or its affiliates. All Rights Reserved."
+[//]: # "SPDX-License-Identifier: CC-BY-SA-4.0"
+
+# Customers should control where encryption context is stored
+
+# Definitions
+
+## MPL
+
+Material Providers Library
+
+## ESDK
+
+Encryption SDK
+
+## Conventions used in this document
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
+interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
+
+# Background
+
+The [branch key store](../../framework/branch-key-store.md) needs to persist branch key versions.
+DynamoDB was selected as an easy to use option.
+However, customers would like additional flexibility.
+Not all customers want to use DDB;
+S3 or Aurora/RDS have all been suggested.
+
+The important aspect about the key store
+is the fact that branch keys can be versioned easily,
+and are cryptographically safe to use.
+The actual storage medium is not important.
+
+# Requirements
+
+1. Customers SHOULD NOT be forced
+   to use a DynamoDB table to store branch keys.
+
+1. Customers SHOULD be able
+   to build a shared key store
+   that abstracts access to the underlying storage.
+
+1. Customers SHOULD have
+   granular control of
+   how information is bound to a branch key item.
+
+# Success Measurements
+
+Clear components that can be used
+outside of Crypto Tools products.
+
+# Out of Scope
+
+- Additional key types
+- Changes to the key store interface
+- Changing how custom encryption context is handled
+
+# Design questions
+
+_**Preferred options are always first and italic like this.**_
+
+# Question: How can customers configure different storage options?
+
+## Option 1: _**Define an extendable interface that customers can implement to suit their storage needs.**_
+
+The operations are already well defined.
+The code is already broken up to identify this information.
+This further bounds the key store to make sure
+that new features are always correctly isolated.
+
+## Option 2: Implement individual options
+
+This is not a tractable option.
+We could implement some,
+but there will always be a missing type.
+Additionally, what about customers
+who want to store their branch keys in DDB,
+but then vend them to downstream microservices?
+This is not a new storage system per se.
+
+## Option 3: Extend the DDB SDK or have interceptors
+
+This is possible, but is not customer focused.
+This adds _huge_ complexity
+and is brittle if we or DDB changes query semantics.
+
+# Question: Should we split the admin functions, (create/version) from the data plane (get)?
+
+## Option 1: _**No, keep all operations in a single client.**_
+
+This makes it easier to implement and
+simplifies customer usage.
+This makes it harder to separate subtle requirements
+between storage and admin.
+If a customer introduces a bug in the data client,
+and fixes it, this fix may not be ported into the admin client.
+
+Crypto Tools would like to encourage customers to limit write access.
+This separation is better done at the key store level.
+Otherwise every client has two flavors
+and this further complicates things.
+Additionally the DDB SDK client is not broken up in this way.
+
+## Option 2: Yes, have a data client and an admin client
+
+Keeping the data client simple makes it easier
+for customers to implement a centralized service
+that can then serve the encrypted form of branch keys.
+They can use the default isolation and only implement
+the functions that they need.
+
+Additionally for the admin client
+there are complicated concurrency checks that are required.
+This kind of locking is not required on the data plane side
+so keeping the dependencies for the ultimate clients simpler.
+
+# Question: How should these operations correspond to the key store operations?
+
+## Option 1: _**Every key store operation should have a single persistance operation.**_
+
+This gives granular control over what operations the key store would support.
+This also clarifies how the key store composes the persistance
+and the authentication/authorization layer.
+
+## Option 2: Simplify operations where possible
+
+This is always possible for the implementer to do.
+Trying to do this on the interface
+is likely premature optimization.
+
+# Question: What inputs should the persistance operation take?
+
+## Option 1: _**The same inputs as the corresponding key store operation.**_
+
+This aligns the interfaces nicely to the key store.
+
+# Question: What type should the persistance operations return?
+
+## Option 1: _**A union of definite types**_
+
+The returned information needs to have the requested branch key.
+It does not need to be a single branch key.
+As we have more branch keys with more versions,
+being able to pack branch key versions together
+may become desirable for performance reasons.
+By packing the branch keys versions together,
+they can all be unwrapped by a single KMS call.
+
+Having an additional optional set of branch keys
+would still result in a KMS call for every branch key.
+
+## Option 2: Definite type
+
+If we only ever wanted to return 1 type this wins.
+It makes the shape well defined and makes branch keys
+in custom systems more correct.
+
+## Option 3: DDB Item
+
+It is easy, but it makes the dependencies strange.
+For customers trying to implement a new storage platform,
+this just adds confusion.
+
+## Option 4: A simple hash map
+
+An easier case of a DDB Item.
+However, this leaves all the difficulty around communicating required fields.
+It is less obvious that some missing information is missing in a simple map.
+
+# Question: How do we evolve the current key store configuration input?
+
+## Option 1: _**Make the DDB members optional and create a new optional union.**_
+
+By making the old interface optional,
+current clients are not broken.
+The current structure constructors for Java and .NET
+are builders and this value could be left off safely.
+This is not safe to do for Dafny,
+but we do not expect to have any direct Dafny customers.
+
+Also, this is entirely isolated to this package.
+So it cannot be broken by combining different versions,
+like say ESDK vX with MPL vY.
+This is all components inside the MPL.
+
+The old optional members should marked as deprecated.
+
+## Option 2: Major version bump for new classes and methods
+
+This makes for a better interface _now_.
+It makes a harder interface to adopt,
+but this only matters for this new feature.
+It makes documentation harder
+because there are now two things
+that are different but the same.
+
+To do this we would need to create
+a new key store service
+and also a new create keyring operation.
+Both of these together result in the same
+keyring that is constructed today.
+
+# Question: How can customers store custom metadata?
+
+(What if I want to use the JSON-ESDK to store my data?)
+
+## Option 1: _**All custom metadata MUST be in encryption context.**_
+
+This is a safe default.
+It mirrors the existing behavior
+and does not complicate the system.
+To the extent that customers want to
+store unauthenticated data they can,
+and it is up to them how this authentication
+is passed to both KMS and the keyring.
+
+## Option 2: Additional optional data properties
+
+This give greater freedom over the structure,
+but it adds complexity to the system.
+In this way there are multiple sets of data
+that need to be authenticated.
+
+Adding this latter is a 2-way door.
+The difficulty is how does this information
+move through the system?
+Is it on the materials and available to the keyring?
+How is it authenticated to KMS?
+
+# Question: Do we also abstract the KMS Client, allowing for custom authorization clients?
+
+## Option 1: _**Only to consolidate the config inputs into a union.**_
+
+It is true that the authorization layer will likely need this abstraction,
+however, the inputs outputs and requirements
+are not 1000% clear.
+By moving the interface to a union,
+this work can be easily added later.
+
+## Option 2: Yes
+
+The authorization layer is similar to the persistance layer.
+There is every expectation
+that this will also need a similar abstraction.
+
+The whole process is simpler to what is outlined above.
+
+## Option 3: No
+
+Having a safe default for the cryptographic authorization
+is the most easy to use/hard to misused option.
+
+# Question: Should the persistance store support CreateKeyStore?
+
+## Option 1: _**No**_
+
+The creation of the key store even in DynamoDB is better handled outside of this component. By creating the key store outside a simple library API it is easier to have fine grained control over creation. Point in time recover is just one example.
+
+## Option 2: Yes
+
+While this may seem to make things easier for customer any custom persistance store will by its nature have a custom creation process. Customers can handle this creation any way they like.
+
+# Question: How do verify correctness of this custom storage component?
+
+## Option 1: _**Checking in the key store only**_
+
+The key store needs these invariants,
+therefore it should verify them.
+On writing we need to assume that a custom component will write what is pass.
+But making sure, for example,
+that all branch key identifiers stored on branch key creation are the same
+is best ensured by the key store.
+
+Similarly, if a branch key is returned, having the key store verify
+that the identifier is what it expects,
+while maybe frustrating,
+is the kind of belt and suspenders correctness we strive for.
+
+## Option 2: Checking in the storage
+
+This shifts the difficulty to the storage component.
+However, this is all "good intentions".
+There is nothing that makes a customer implement these things correctly.
+So we end up checking in the key store or leaving this as a potential sharp edge.
+
+This is not [hard to misuse](../../tenets.md#hard-to-misuse).
+
+## Option 3: Checking in both
+
+This does not help customers and adds more checking everywhere.
+It is not clear how this is better.
+
+# Proposal
+
+Changes to the [Key Store's Smithy Model](https://github.com/aws/aws-cryptographic-material-providers-library/blob/main/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/Model/KeyStore.smithy#L65-L358)
+This is seen in [proposed.smithy](./proposed.smithy)
+
+# One-Way Doors
+
+- API changes live forever.
+
+# Security Considerations
+
+It is now possible for customers
+to store and retrieve branch keys
+on data that is not authenticated.
+
+This means that the various invariants
+that the key store expects
+MUST be maintained by the customer implementation.
+
+For example:
+
+1. Branch key insert MUST be an atomic transaction.
+   The Active Branch Key, Versioned Branch Key, Beacon Key
+   need to either all be written or none of them are written.
+   Writing one or two of the three
+   makes the persistance store inconsistent.
+1. Branch key insert MUST fail if a duplicate branch key id already exists.
+1. Branch key version insert MUST be an atomic transaction
+   Similar to inserting a new branch key,
+   both the Active Branch Key, Versioned Branch Key
+   need to either both succeed or both fail.
+
+Any future persistence needs of the Key Store
+would require Crypto Tools to evolve the interface
+and customers to refactor their implementations
+to comply with such needs.
+Ideally, these would happen via optional behaviors of the Key Store,
+as compared to required behaviors that would break custom implementations.
+
+# Impact/Other considerations
+
+This expands the API surface area and customization options.
+Having more options is not always better.
+This will add to our docs and our support
+as customers explore how to use these options.
+
+This will increase our operational load
+as more customers try to understand
+and implement their own interfaces.
+
+# Assumptions
+
+- Composing interfaces bounds options.
+  This "don't call me, I'll call you"
+  kind of injection is powerful,
+  but also limits composition.
+  The assumption is that bounding these options
+  is a good thing.
+
+# Open Questions
+
+None at this time.

--- a/changes/2024-6-17_key-store-persistance/proposed.smithy
+++ b/changes/2024-6-17_key-store-persistance/proposed.smithy
@@ -1,0 +1,152 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+structure KeyStoreConfig {
+
+  @required
+  kmsConfiguration: KMSConfiguration,
+  @required
+  logicalKeyStoreName: String,
+
+  id: String,
+
+  // These properties are about storage
+  storage: Storage
+  ddbTableName: TableName,
+  ddbClient: DdbClientReference,
+
+  // These properties are about authentication/authorization
+  auth: Auth,
+  grantTokens: GrantTokenList,
+  kmsClient: KmsClientReference,
+
+}
+
+union Storage {
+  ddb: DynamoDBTable
+  custom: EncryptedKeyStore
+}
+
+structure DynamoDBTable {
+  @required
+  ddbTableName: TableName,
+  ddbClient: DdbClientReference,
+}
+
+union Auth {
+  kms: AwsKms,
+}
+
+structure AwsKms {
+  grantTokens: GrantTokenList,
+  kmsClient: KmsClientReference,
+}
+
+enum BranchKeyType {
+    ACTIVE_BRANCH_KEY
+    BRANCH_KEY_VERSION
+}
+
+enum BranchKeyKind {
+  HIERARCHICAL_SYMMETRIC
+}
+
+structure EncryptedBranchKey {
+  @required
+  Identifier: Utf8Bytes,
+
+  @required
+  Type: BranchKeyType,
+
+  @required
+  Kind: BranchKeyKind,
+
+  @required
+  Version: Utf8Bytes,
+
+  @required
+  CreateTime: Utf8Bytes,
+
+  @required
+  KmsArn: Utf8Bytes,
+
+  @required
+  EncryptionContext: EncryptionContext,
+
+  @required
+  CiphertextBlob: blob,
+}
+
+structure EncryptedBeaconKey {
+  @required
+  Identifier: Utf8Bytes,
+
+  @required
+  CreateTime: Utf8Bytes,
+
+  @required
+  KmsArn: Utf8Bytes,
+
+  @required
+  EncryptionContext: EncryptionContext,
+
+  @required
+  CiphertextBlob: blob,
+}
+
+union EncryptedBranchItem {
+  BranchKey: EncryptedBranchKey
+}
+
+union EncryptedBeaconItem {
+  BeaconKey: EncryptedBeaconKey
+}
+
+@extendable
+resource EncryptedKeyStore {
+  operations: [
+    GetEncryptedActiveBranchKey,
+    GetEncryptedBranchKeyVersion,
+    GetEncryptedBeaconKey,
+  ]
+}
+
+@reference(resource: EncryptedKeyStore)
+structure EncryptedKeyStoreReference {}
+
+operation GetEncryptedActiveBranchKey {
+  input: GetEncryptedActiveBranchKeyInput,
+  output: GetEncryptedActiveBranchKeyOutput,
+}
+operation GetEncryptedBranchKeyVersion {
+  input: GetEncryptedBranchKeyVersionInput,
+  output: GetEncryptedBranchKeyVersionOutput,
+}
+operation GetEncryptedBeaconKey {
+  input: GetEncryptedBeaconKeyInput,
+  output: GetEncryptedBeaconKeyOutput,
+}
+
+structure GetEncryptedActiveBranchKeyInput{
+  @required
+  Identifier: Utf8Bytes,
+}
+structure GetEncryptedActiveBranchKeyOutput{
+  Item: EncryptedBranchItem,
+}
+structure GetEncryptedBranchKeyVersionInput{
+  @required
+  Identifier: Utf8Bytes,
+  @required
+  Version: Utf8Bytes,
+}
+structure GetEncryptedBranchKeyVersionOutput{
+  Item: EncryptedBranchItem,
+}
+structure GetEncryptedBeaconKeyInput{
+  @required
+  Identifier: Utf8Bytes,
+}
+structure GetEncryptedBeaconKeyOutput{
+  Item: EncryptedBeaconItem,
+}

--- a/framework/branch-key-store.md
+++ b/framework/branch-key-store.md
@@ -5,10 +5,12 @@
 
 ## Version
 
-0.5.0
+0.6.0
 
 ### Changelog
 
+- 0.6.0
+  - Introduce configurable storage options
 - 0.5.0
   - Introduce KMS Configuration of MRDiscovery
 - 0.4.0
@@ -31,18 +33,18 @@
 ## Overview
 
 A Keystore persists hierarchical data that allows customers to call AWS KMS less often.
-The Keystore persists branch keys in DynamoDb that wrap multiple data keys.
+The Keystore persists branch keys that wrap multiple data keys.
 This creates a hierarchy where a branch key wraps multiple data keys and facilitates caching.
 These branch keys are only generated using the [AWS KMS API GenerateDataKeyWithoutPlaintext](https://docs.aws.amazon.com/kms/latest/APIReference/API_GenerateDataKeyWithoutPlaintext.html).
 
-By creating and persisting a data key to an accesbile medium,
+By creating and persisting a data key to an accessible medium,
 such as a DynamoDb table,
-distributed cryptographic agents can use a common, coordinated, cryptographic materials.
+distributed cryptographic agents can use common, coordinated, cryptographic materials.
 
 This prevents distributed cryptographic agents from independently
 generating unique data keys that COULD BE coordinated,
 which leads to poor caching performance at decryption,
-as each unqiue encrypting agent had a unqiue data key.
+as each unique encrypting agent had a unique data key.
 
 This Keystore interface defines operations that any implementation of its specification must support and implement.
 
@@ -65,14 +67,63 @@ The following inputs MAY be specified to create a KeyStore:
 
 - [ID](#keystore-id)
 - [AWS KMS Grant Tokens](#aws-kms-grant-tokens)
+- [Storage](#storage)
 - [DynamoDb Client](#dynamodb-client)
+- [Table Name](#table-name)
 - [KMS Client](#kms-client)
+- [KeyManagement](#keymanagement)
 
 The following inputs MUST be specified to create a KeyStore:
 
-- [Table Name](#table-name)
 - [AWS KMS Configuration](#aws-kms-configuration)
 - [Logical KeyStore Name](#logical-keystore-name)
+
+If neither [Storage](#storage) nor [Table Name](#table-name) is configured initialization MUST fail.
+If both [Storage](#storage) and [Table Name](#table-name) are configured initialization MUST fail.
+If both [Storage](#storage) and [DynamoDb Client](#dynamodb-client) are configured initialization MUST fail.
+If both [KeyManagement](#keymanagement) and [KMS Client](#kms-client) are configured initialization MUST fail.
+If both [KeyManagement](#keymanagement) and [Grant Tokens](#aws-kms-grant-tokens) are configured initialization MUST fail.
+
+If [Storage](#storage) is configured with an [EncryptedKeyStore](#encryptedkeystore)
+then this MUST be the configured [EncryptedKeyStore interface](./key-store/encrypted-key-store.md#interface).
+
+If [Storage](#storage) is not configured with an [EncryptedKeyStore](#encryptedkeystore)
+a [default encrypted key store](./key-store/default-encrypted-key-store.md#initialization) MUST be created.
+
+This constructed [default encrypted key store](./key-store/default-encrypted-key-store.md#overview)
+MUST be configured with the provided [logical keystore name](#logical-keystore-name).
+
+This constructed [default encrypted key store](./key-store/default-encrypted-key-store.md#initialization)
+MUST be configured with either the [Table Name](#table-name) or the [DynamoDBTable](#dynamodbtable) table name
+depending on which one is configured.
+
+This constructed [default encrypted key store](./key-store/default-encrypted-key-store.md#initialization)
+MUST be configured with either the [DynamoDb Client](#dynamodb-client), the DDB client in the [DynamoDBTable](#dynamodbtable)
+or a constructed DDB client depending on what is configured.
+
+If a DDB client needs to be constructed and the AWS KMS Configuration is KMS Key ARN or KMS MRKey ARN,
+a new DynamoDb client MUST be created with the region of the supplied KMS ARN.
+
+If a DDB client needs to be constructed and the AWS KMS Configuration is Discovery,
+a new DynamoDb client MUST be created with the default configuration.
+
+If a DDB client needs to be constructed and the AWS KMS Configuration is MRDiscovery,
+a new DynamoDb client MUST be created with the region configured in the MRDiscovery.
+
+If no AWS KMS client is provided one MUST be constructed.
+
+If AWS KMS client needs to be constructed and the AWS KMS Configuration is KMS Key ARN or KMS MRKey ARN,
+a new AWS KMS client MUST be created with the region of the supplied KMS ARN.
+
+If AWS KMS client needs to be constructed and the AWS KMS Configuration is Discovery,
+a new AWS KMS client MUST be created with the default configuration.
+
+If AWS KMS client needs to be constructed and the AWS KMS Configuration is MRDiscovery,
+a new AWS KMS client MUST be created with the region configured in the MRDiscovery.
+
+On initialization the KeyStore SHOULD
+append a user agent string to the AWS KMS SDK Client with
+the value `aws-kms-hierarchy`.
 
 ### Keystore ID
 
@@ -86,48 +137,17 @@ A list of AWS KMS [grant tokens](https://docs.aws.amazon.com/kms/latest/develope
 ### DynamoDb Client
 
 The DynamoDb Client used to put and get keys from the backing DDB table.
-
-If the AWS KMS Configuration is KMS Key ARN or KMS MRKey ARN,
-and no DynamoDb Client is provided,
-a new DynamoDb Client MUST be created
-with the region of the supplied KMS ARN.
-
-If the AWS KMS Configuration is Discovery,
-and no DynamoDb Client is provided,
-a new DynamoDb Client MUST be created
-with the default configuration.
-
-If the AWS KMS Configuration is MRDiscovery,
-and no DynamoDb Client is provided,
-a new DynamoDb Client MUST be created
-with the region configured in the MRDiscovery.
+This options is deprecated in favor of [storage](#storage)
 
 ### KMS Client
 
 The KMS Client used when wrapping and unwrapping keys.
-
-If the AWS KMS Configuration is KMS Key ARN or KMS MRKey ARN,
-and no KMS Client is provided,
-a new KMS Client MUST be created
-with the region of the supplied KMS ARN.
-
-If the AWS KMS Configuration is Discovery,
-and no KMS Client is provided,
-a new KMS Client MUST be created
-with the default configuration.
-
-If the AWS KMS Configuration is MRDiscovery,
-and no KMS Client is provided,
-a new KMS Client MUST be created
-with the region configured in the MRDiscovery.
-
-On initialization the KeyStore SHOULD
-append a user agent string to the AWS KMS SDK Client with
-the value `aws-kms-hierarchy`.
+This options is deprecated in favor of [KeyManagement](#keymanagement)
 
 ### Table Name
 
 The table name of the DynamoDb table that backs this Keystore.
+This options is deprecated in favor of [storage](#storage)
 
 ### AWS KMS Configuration
 
@@ -156,6 +176,36 @@ and a KMS ARN for non Multi-Region Key MAY be provided to the `KMS MRKey ARN` co
 
 `MRDiscovery` MUST take an additional argument, which is a region.
 Any MRK ARN discovered will be changed to this region before use.
+
+### Storage
+
+This configures how the Keystore will get encrypted data.
+There are two valid storage options:
+
+- DynamoDBTable
+- EncryptedKeyStore
+
+#### DynamoDBTable
+
+A DynamoDBTable configuration MUST take the DynamoDB table name.
+A DynamoDBTable configuration MAY take [DynamoDb Client](#dynamodb-client).
+
+#### EncryptedKeyStore
+
+An [EncryptedKeyStore interface](./key-store/encrypted-key-store.md#interface)
+
+### KeyManagement
+
+This configures how the Keystore will authenticate encrypted data
+or create new branch keys.
+There is one valid storage option:
+
+- AwsKms
+
+#### AwsKms
+
+An AwsKms configuration MAY take a list of AWS KMS [grant tokens](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token).
+An AwsKms configuration MAY take an [AWS KMS SDK client](#awskms).
 
 #### AWS Key ARN Compatibility
 
@@ -238,7 +288,13 @@ This MUST include:
 - [AWS KMS Grant Tokens](#aws-kms-grant-tokens)
 - [AWS KMS Configuration](#aws-kms-configuration)
 
+The [keystore name](#table-name) MUST be obtained
+from the configured [EncryptedKeyStore interface](./key-store/encrypted-key-store.md#interface)
+by calling [GetTableName](./key-store/encrypted-key-store.md#gettablename).
+
 ### CreateKeyStore
+
+If a [table Name](#table-name) was not configured then CreateKeyStore MUST fail.
 
 This operation MUST first calls the DDB::DescribeTable API with the configured `tableName`.
 
@@ -292,7 +348,8 @@ This operation MUST create a [branch key](structures.md#branch-key) and a [beaco
 the [Branch Key and Beacon Key Creation](#branch-key-and-beacon-key-creation) section.
 
 If creation of the keys are successful,
-the operation MUST call Amazon DynamoDB TransactWriteItems according to the [write key material](#writing-branch-key-and-beacon-key-to-keystore) section.
+then the key store MUST call the configured [EncryptedKeyStore interface's](./key-store/encrypted-key-store.md#interface)
+[WriteNewKeyToStore](./key-store/encrypted-key-store.md#writenewkeytostore) with these 3 [EncryptedHierarchicalKeys](./key-store/encrypted-key-store.md#encryptedhierarchicalkey).
 
 If writing to the keystore succeeds,
 the operation MUST return the branch-key-id that maps to both
@@ -360,59 +417,6 @@ If the call to AWS KMS ReEncrypt succeeds,
 the operation MUST use the ReEncrypt result `CiphertextBlob`
 as the wrapped ACTIVE Branch Key.
 
-#### Writing Branch Key and Beacon Key to Keystore
-
-To add the branch keys and a beacon key to the keystore the
-operation MUST call [Amazon DynamoDB API TransactWriteItems](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_TransactWriteItems.html).
-The call to Amazon DynamoDB TransactWriteItems MUST use the configured Amazon DynamoDB Client to make the call.
-The operation MUST call Amazon DynamoDB TransactWriteItems with a request constructed as follows:
-
-List of TransactWriteItem:
-
-- PUT:
-  - Item:
-    - “branch-key-id” (S): `branchKeyId`,
-    - “type“ (S): "branch:version:" + `version`,
-    - “enc” (B): the wrapped DECRYPT_ONLY Branch Key `CiphertextBlob` from the KMS operation
-    - “create-time” (S): `timestamp`
-    - "kms-arn" (S): configured KMS Key
-    - “hierarchy-version” (N): 1
-    - Every key-value pair of the custom [encryption context](./structures.md#encryption-context-3) that is associated with the branch key
-      MUST be added with an Attribute Name of `aws-crypto-ec:` + the Key and Attribute Value (S) of the value.
-  - ConditionExpression: `attribute_not_exists(branch-key-id)`
-  - TableName: the configured Table Name
-- PUT:
-  - Item:
-    - “branch-key-id” (S): `branchKeyId`,
-    - “type“ (S): "branch:ACTIVE",
-    - “enc” (B): wrapped ACTIVE Branch Key `CiphertextBlob` from the KMS operation
-    - “create-time” (S): `timestamp`
-    - "kms-arn" (S): configured KMS Key
-    - “hierarchy-version” (N): 1
-    - Every key-value pair of the custom [encryption context](./structures.md#encryption-context-3) that is associated with the branch key
-      MUST be added with an Attribute Name of `aws-crypto-ec:` + the Key and Attribute Value (S) of the value.
-  - ConditionExpression: `attribute_not_exists(branch-key-id)`
-  - TableName: the configured Table Name
-- PUT:
-  - Item:
-    - “branch-key-id” (S): `branchKeyId`,
-    - “type“ (S): "beacon:ACTIVE",
-    - “enc” (B): the wrapped Beacon Key `CiphertextBlob` from the KMS operation
-    - “create-time” (S): `timestamp`
-    - "kms-arn" (S): configured KMS Key
-    - “hierarchy-version” (N): 1
-    - Every key-value pair of the custom [encryption context](./structures.md#encryption-context-3) that is associated with the branch key
-      MUST be added with an Attribute Name of `aws-crypto-ec:` + the Key and Attribute Value (S) of the value.
-  - ConditionExpression: `attribute_not_exists(branch-key-id)`
-  - TableName is the configured Table Name
-
-TransactWriteItemRequest:
-
-- TransactWriteItems: List of TransactWriteItem
-
-If DDB TransactWriteItems is successful, this operation MUST return a successful response containing no additional data.
-Otherwise, this operation MUST yield an error.
-
 ### VersionKey
 
 On invocation, the caller:
@@ -423,84 +427,52 @@ If the Keystore's KMS Configuration is `Discovery` or `MRDiscovery`,
 this operation MUST immediately fail.
 
 VersionKey MUST first get the active version for the branch key from the keystore
-by calling AWS DDB `GetItem`
-using the `branch-key-id` as the Partition Key and `"branch:ACTIVE"` value as the Sort Key.
+by calling the configured [EncryptedKeyStore interface's](./key-store/encrypted-key-store.md#interface)
+[GetEncryptedActiveBranchKey](./key-store/encrypted-key-store.md##getencryptedactivebranchkey)
+using the `branch-key-id`.
 
-The `kms-arn` field of DDB response item MUST be [compatible with](#aws-key-arn-compatibility)
+The `KmsArn` of the [EncryptedHierarchicalKey](./key-store/encrypted-key-store.md##encryptedhierarchicalkey)
+MUST be [compatible with](#aws-key-arn-compatibility)
 the configured `KMS ARN` in the [AWS KMS Configuration](#aws-kms-configuration) for this keystore.
 
-The `kms-arn` stored in the DDB table MUST NOT change as a result of this operation,
+Because the storage interface can be a custom implementation the key store needs to verify correctness.
+
+VersionKey MUST verify that the returned EncryptedHierarchicalKey MUST have the requested `branch-key-id`.
+VersionKey MUST verify that the returned EncryptedHierarchicalKey is an ActiveHierarchicalSymmetricVersion.
+VersionKey MUST verify that the returned EncryptedHierarchicalKey MUST have a logical table name equal to the configured logical table name.
+
+The `kms-arn` stored in the table MUST NOT change as a result of this operation,
 even if the KeyStore is configured with a `KMS MRKey ARN` that does not exactly match the stored ARN.
 If such were allowed, clients using non-MRK KeyStores might suddenly stop working.
 
-The values on the AWS DDB response item
-MUST be authenticated according to [authenticating a keystore item](#authenticating-a-keystore-item).
+The [EncryptedHierarchicalKey](./key-store/encrypted-key-store.md##encryptedhierarchicalkey)
+MUST be authenticated according to [authenticating a keystore item](#authenticating-an-encryptedhierarchicalkey).
 If the item fails to authenticate this operation MUST fail.
 
 The wrapped Branch Keys, DECRYPT_ONLY and ACTIVE, MUST be created according to [Wrapped Branch Key Creation](#wrapped-branch-key-creation).
 
-To add the new branch key to the keystore,
-the operation MUST call [Amazon DynamoDB API TransactWriteItems](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_TransactWriteItems.html).
-The call to Amazon DynamoDB TransactWriteItems MUST use the configured Amazon DynamoDB Client to make the call.
-The operation MUST call Amazon DynamoDB TransactWriteItems with a request constructed as follows:
+If creation of the keys are successful,
+then the key store MUST call the configured [EncryptedKeyStore interface's](./key-store/encrypted-key-store.md#interface)
+[WriteNewBranchKeyVersionToKeystore](./key-store/encrypted-key-store.md##writenewbranchkeyversiontokeystore)
+with these 2 [EncryptedHierarchicalKeys](./key-store/encrypted-key-store.md##encryptedhierarchicalkey).
 
-List of TransactWriteItem:
-
-- PUT:
-  - Item:
-    - “branch-key-id” (S): `branchKeyId`,
-    - “type“ (S): "branch:version:" + `version`,
-    - “enc” (B): the wrapped DECRYPT_ONLY Branch Key `CiphertextBlob` from the KMS operation
-    - “create-time” (S): `timestamp`
-    - "kms-arn" (S): configured KMS Key
-    - “hierarchy-version” (N): 1
-    - Every key-value pair of the custom [encryption context](./structures.md#encryption-context-3) that is associated with the branch key
-      MUST be added with an Attribute Name of `aws-crypto-ec:` + the Key and Attribute Value (S) of the value.
-  - ConditionExpression: `attribute_not_exists(branch-key-id)`
-  - TableName: the configured Table Name
-- PUT:
-  - Item:
-    - “branch-key-id” (S): `branchKeyId`,
-    - “type“ (S): "branch:ACTIVE",
-    - “enc” (B): wrapped ACTIVE Branch Key `CiphertextBlob` from the KMS operation
-    - “create-time” (S): `timestamp`
-    - "kms-arn" (S): configured KMS Key
-    - “hierarchy-version” (N): 1
-    - Every key-value pair of the custom [encryption context](./structures.md#encryption-context-3) that is associated with the branch key
-      MUST be added with an Attribute Name of `aws-crypto-ec:` + the Key and Attribute Value (S) of the value.
-  - ConditionExpression: `attribute_exists(branch-key-id)`
-  - TableName: the configured Table Name
-
-TransactWriteItemRequest:
-
-- TransactWriteItems: List of TransactWriteItem
-
-If DDB TransactWriteItems is successful, this operation MUST return a successful response containing no additional data.
+If the [WriteNewBranchKeyVersionToKeystore](./key-store/encrypted-key-store.md##writenewbranchkeyversiontokeystore) is successful,
+this operation MUST return a successful response containing no additional data.
 Otherwise, this operation MUST yield an error.
 
-#### Authenticating a Keystore item
+#### Authenticating an EncryptedHierarchicalKey
 
 The operation MUST use the configured `KMS SDK Client` to authenticate the value of the keystore item.
-
-Every attribute on the AWS DDB response item will be authenticated.
-
-Every key in the constructed [encryption context](#encryption-context)
-except `tableName`
-MUST exist as a string attribute in the AWS DDB response item.
-Every value in the constructed [encryption context](#encryption-context)
-except the logical table name
-MUST equal the value with the same key in the AWS DDB response item.
-The key `enc` MUST NOT exist in the constructed [encryption context](#encryption-context).
 
 The operation MUST call [AWS KMS API ReEncrypt](https://docs.aws.amazon.com/kms/latest/APIReference/API_ReEncrypt.html)
 with a request constructed as follows:
 
-- `SourceEncryptionContext` MUST be the [encryption context](#encryption-context) constructed above
+- `SourceEncryptionContext` MUST be the [encryption context](#encryption-context) of the EncryptedHierarchicalKey to be authenticated
 - `SourceKeyId` MUST be [compatible with](#aws-key-arn-compatibility) the configured KMS Key in the [AWS KMS Configuration](#aws-kms-configuration) for this keystore.
-- `CiphertextBlob` MUST be the `enc` attribute value on the AWS DDB response item
+- `CiphertextBlob` MUST be the `CiphertextBlob` attribute value on the EncryptedHierarchicalKey to be authenticated
 - `GrantTokens` MUST be the configured [grant tokens](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token).
 - `DestinationKeyId` MUST be [compatible with](#aws-key-arn-compatibility) the configured KMS Key in the [AWS KMS Configuration](#aws-kms-configuration) for this keystore.
-- `DestinationEncryptionContext` MUST be the [encryption context](#encryption-context) constructed above
+- `DestinationEncryptionContext` MUST be the [encryption context](#encryption-context) of the EncryptedHierarchicalKey to be authenticated
 
 ### GetActiveBranchKey
 
@@ -508,14 +480,18 @@ On invocation, the caller:
 
 - MUST supply a `branch-key-id`
 
-To get the active version for the branch key id from the keystore
-this operation MUST call AWS DDB `GetItem`
-using the `branch-key-id` as the Partition Key and `"branch:ACTIVE"` value as the Sort Key.
+GetActiveBranchKey MUST get the active version for the branch key id from the keystore
+by calling the configured [EncryptedKeyStore interface's](./key-store/encrypted-key-store.md#interface)
+[GetEncryptedActiveBranchKey](./key-store/encrypted-key-store.md#getencryptedactivebranchkey)
+using the supplied `branch-key-id`.
 
-The AWS DDB response MUST contain the fields defined in the [branch keystore record format](#record-format).
-If the record does not contain the defined fields, this operation MUST fail.
+Because the storage interface can be a custom implementation the key store needs to verify correctness.
 
-The operation MUST decrypt the branch key according to the [AWS KMS Branch Key Decryption](#aws-kms-branch-key-decryption) section.
+GetActiveBranchKey MUST verify that the returned EncryptedHierarchicalKey MUST have the requested `branch-key-id`.
+GetActiveBranchKey MUST verify that the returned EncryptedHierarchicalKey is an ActiveHierarchicalSymmetricVersion.
+GetActiveBranchKey MUST verify that the returned EncryptedHierarchicalKey MUST have a logical table name equal to the configured logical table name.
+
+The operation MUST decrypt the EncryptedHierarchicalKey according to the [AWS KMS Branch Key Decryption](#aws-kms-branch-key-decryption) section.
 
 If the branch key fails to decrypt, GetActiveBranchKey MUST fail.
 
@@ -531,11 +507,17 @@ On invocation, the caller:
 - MUST supply a `branch-key-id`
 - MUST supply a `branchKeyVersion`
 
-To get a branch key from the keystore this operation MUST call AWS DDB `GetItem`
-using the `branch-key-id` as the Partition Key and "branch:version:" + `branchKeyVersion` value as the Sort Key.
+GetBranchKeyVersion MUST get the requested version for the branch key id from the keystore
+by calling the configured [EncryptedKeyStore interface's](./key-store/encrypted-key-store.md#interface)
+[GetEncryptedActiveBranchKey](./key-store/encrypted-key-store.md#getencryptedbranchkeyversion)
+using the supplied `branch-key-id`.
 
-The AWS DDB response MUST contain the fields defined in the [branch keystore record format](#record-format).
-If the record does not contain the defined fields, this operation MUST fail.
+Because the storage interface can be a custom implementation the key store needs to verify correctness.
+
+GetBranchKeyVersion MUST verify that the returned EncryptedHierarchicalKey MUST have the requested `branch-key-id`.
+GetBranchKeyVersion MUST verify that the returned EncryptedHierarchicalKey MUST have the requested `branchKeyVersion`.
+GetActiveBranchKey MUST verify that the returned EncryptedHierarchicalKey is an HierarchicalSymmetricVersion.
+GetBranchKeyVersion MUST verify that the returned EncryptedHierarchicalKey MUST have a logical table name equal to the configured logical table name.
 
 The operation MUST decrypt the branch key according to the [AWS KMS Branch Key Decryption](#aws-kms-branch-key-decryption) section.
 
@@ -552,11 +534,16 @@ On invocation, the caller:
 
 - MUST supply a `branch-key-id`
 
-To get a branch key from the keystore this operation MUST call AWS DDB `GetItem`
-using the `branch-key-id` as the Partition Key and "beacon:ACTIVE" value as the Sort Key.
+GetBeaconKey MUST get the requested beacon key from the keystore
+by calling the configured [EncryptedKeyStore interface's](./key-store/encrypted-key-store.md#interface)
+[GetEncryptedBeaconKey](./key-store/encrypted-key-store.md#getencryptedbeaconkey)
+using the supplied `branch-key-id`.
 
-The AWS DDB response MUST contain the fields defined in the [branch keystore record format](#record-format).
-If the record does not contain the defined fields, this operation MUST fail.
+Because the storage interface can be a custom implementation the key store needs to verify correctness.
+
+GetBeaconKey MUST verify that the returned EncryptedHierarchicalKey MUST have the requested `branch-key-id`.
+GetBeaconKey MUST verify that the returned EncryptedHierarchicalKey is an ActiveHierarchicalSymmetricBeacon.
+GetBeaconKey MUST verify that the returned EncryptedHierarchicalKey MUST have a logical table name equal to the configured logical table name.
 
 The operation MUST decrypt the beacon key according to the [AWS KMS Branch Key Decryption](#aws-kms-branch-key-decryption) section.
 
@@ -570,7 +557,7 @@ This operation MUST return the constructed [beacon key materials](./structures.m
 ## Encryption Context
 
 This section describes how the AWS KMS encryption context is built
-from the DynamoDB items that store the branch keys.
+from an [encrypted hierarchical key](./key-store/encrypted-key-store.md#encryptedhierarchicalkey).
 
 The following encryption context keys are shared:
 
@@ -584,7 +571,8 @@ The following encryption context keys are shared:
 - MUST have a `hierarchy-version`
 - MUST NOT have a `enc` attribute
 
-Any additionally attributes on the DynamoDB item
+Any additionally attributes in the EncryptionContext
+of the [encrypted hierarchical key](./key-store/encrypted-key-store.md#encryptedhierarchicalkey)
 MUST be added to the encryption context.
 
 ### ACTIVE Encryption Context
@@ -624,17 +612,6 @@ Across all versions of a Branch Key, the custom encryption context MUST be equal
 
 The operation MUST use the configured `KMS SDK Client` to decrypt the value of the branch key field.
 
-Every attribute except for `enc` on the AWS DDB response item
-MUST be authenticated in the decryption of `enc`
-
-Every key in the constructed [encryption context](#encryption-context)
-except `tableName`
-MUST exist as a string attribute in the AWS DDB response item.
-Every value in the constructed [encryption context](#encryption-context)
-except the logical table name
-MUST equal the value with the same key in the AWS DDB response item.
-The key `enc` MUST NOT exist in the constructed [encryption context](#encryption-context).
-
 If the Keystore's [AWS KMS Configuration](#aws-kms-configuration) is `KMS Key ARN` or `KMS MRKey ARN`,
 the `kms-arn` field of the DDB response item MUST be
 [compatible with](#aws-key-arn-compatibility) the configured KMS Key in
@@ -653,32 +630,9 @@ the keystore operation MUST call with a request constructed as follows:
 - `KeyId`, if the KMS Configuration is Discovery, MUST be the `kms-arn` attribute value of the AWS DDB response item.
   If the KMS Configuration is MRDiscovery, `KeyId` MUST be the `kms-arn` attribute value of the AWS DDB response item, with the region replaced by the configured region.
   Otherwise, it MUST BE the Keystore's configured KMS Key.
-- `CiphertextBlob` MUST be the `enc` attribute value on the AWS DDB response item
-- `EncryptionContext` MUST be the [encryption context](#encryption-context) constructed above
+- `CiphertextBlob` MUST be the `CiphertextBlob` attribute value on the provided EncryptedHierarchicalKey
+- `EncryptionContext` MUST be the [encryption context](#encryption-context) of the provided EncryptedHierarchicalKey
 - `GrantTokens` MUST be this keystore's [grant tokens](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token).
-
-## Record Format
-
-A branch key record MUST include the following key-value pairs:
-
-1. `branch-key-id` : Unique identifier for a branch key; represented as [AWS DDB String](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes)
-1. `type` : One of the following; represented as [AWS DDB String](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes)
-   - The string literal `"beacon:ACTIVE"`. Then `enc` is the wrapped beacon key.
-   - The string `"branch:version:"` + `version`, where `version` is the Branch Key Version. Then `enc` is the wrapped branch key.
-   - The string literal `"branch:ACTIVE"`. Then `enc` is the wrapped beacon key of the active version. Then
-1. `version` : Only exists if `type` is the string literal `"branch:ACTIVE"`.
-   Then it is the Branch Key Version. represented as [AWS DDB String](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes)
-1. `enc` : Encrypted version of the key;
-   represented as [AWS DDB Binary](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes)
-1. `kms-arn`: The AWS KMS Key ARN used to generate the `enc` value.
-   represented as [AWS DDB String](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes)
-1. `create-time`: Timestamp in ISO 8601 format in UTC, to microsecond precision.
-   Represented as [AWS DDB String](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes)
-1. `hierarchy-version`: Version of the hierarchical keyring;
-   represented as [AWS DDB Number](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes)
-
-A branch key record MAY include [custom encryption context](#custom-encryption-context) key-value pairs.
-These attributes should be prefixed with `aws-crypto-ec:` the same way they are for [AWS KMS encryption context](#encryption-context).
 
 ### Branch Key Materials From Authenticated Encryption Context
 

--- a/framework/key-store/default-encrypted-key-store.md
+++ b/framework/key-store/default-encrypted-key-store.md
@@ -1,0 +1,17 @@
+[//]: # "Copyright Amazon.com Inc. or its affiliates. All Rights Reserved."
+[//]: # "SPDX-License-Identifier: CC-BY-SA-4.0"
+
+# Default Encrypted Key Store
+
+## Version
+
+0.1.0
+
+### Changelog
+
+- 0.1.0
+  - Initial record
+
+## Overview
+
+The Default Encrypted Key Store is the [Dynamodb Encrypted Key Store](./default-encrypted-key-store.md#overview).

--- a/framework/key-store/dynamodb-encrypted-key-store.md
+++ b/framework/key-store/dynamodb-encrypted-key-store.md
@@ -1,0 +1,165 @@
+[//]: # "Copyright Amazon.com Inc. or its affiliates. All Rights Reserved."
+[//]: # "SPDX-License-Identifier: CC-BY-SA-4.0"
+
+# Dynamodb Encrypted Key Store
+
+## Version
+
+0.1.0
+
+### Changelog
+
+- 0.1.0
+  - Initial record
+
+## Implementations
+
+| Language | Confirmed Compatible with Spec Version | Minimum Version Confirmed | Implementation |
+| -------- | -------------------------------------- | ------------------------- | -------------- |
+
+## Overview
+
+The Dynamodb Encrypted Key Store is the default implementation of the [encrypted key store interface](./encrypted-key-store.md#overview)
+used by the [key store](../branch-key-store.md#overview).
+It is backed by DynamoDB and can be used as a reference for customers implementing their own interface.
+
+## Definitions
+
+### Conventions used in this document
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL"
+in this document are to be interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
+
+## Initialization
+
+The following inputs MUST be specified to create a Default Encrypted Key Store:
+
+- [DynamoDb Client](#dynamodb-client)
+- [Table Name](#table-name)
+- [Logical KeyStore Name](#logical-keystore-name)
+
+### DynamoDb Client
+
+The DynamoDb Client used to put and get keys from the backing DDB table.
+
+### Table Name
+
+The table name of the DynamoDb table that backs this Keystore.
+
+### Logical KeyStore Name
+
+This name is cryptographically bound to all data stored in this table,
+and logically separates data between different tables.
+
+It is not stored on the items in the so it MUST be added
+to items retrieved from the table.
+
+## Operations
+
+The Default Encrypted Key Store MUST implement the [encrypted key store interface](./encrypted-key-store.md#interface)..
+
+### WriteNewKeyToStore
+
+To add the branch keys and a beacon key to the keystore the
+operation MUST call [Amazon DynamoDB API TransactWriteItems](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_TransactWriteItems.html).
+The call to Amazon DynamoDB TransactWriteItems MUST use the configured Amazon DynamoDB Client to make the call.
+The operation MUST call Amazon DynamoDB TransactWriteItems with a request constructed as follows:
+
+List of TransactWriteItem:
+
+- PUT:
+  - Item: A [record formatted item](#record-format) constructed from the version input
+  - ConditionExpression: `attribute_not_exists(branch-key-id)`
+  - TableName: the configured Table Name
+- PUT:
+  - Item: A [record formatted item](#record-format) constructed from the active input
+  - ConditionExpression: `attribute_not_exists(branch-key-id)`
+  - TableName: the configured Table Name
+- PUT:
+  - Item: A [record formatted item](#record-format) constructed from the beacon input
+  - ConditionExpression: `attribute_not_exists(branch-key-id)`
+  - TableName is the configured Table Name
+
+TransactWriteItemRequest:
+
+- TransactWriteItems: List of TransactWriteItem
+
+If DDB TransactWriteItems is successful, this operation MUST return a successful response containing no additional data.
+Otherwise, this operation MUST yield an error.
+
+### WriteNewBranchKeyVersionToKeystore
+
+To add the new branch key to the keystore,
+the operation MUST call [Amazon DynamoDB API TransactWriteItems](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_TransactWriteItems.html).
+The call to Amazon DynamoDB TransactWriteItems MUST use the configured Amazon DynamoDB Client to make the call.
+The operation MUST call Amazon DynamoDB TransactWriteItems with a request constructed as follows:
+
+List of TransactWriteItem:
+
+- PUT:
+  - Item: A [record formatted item](#record-format) constructed from the version input
+  - ConditionExpression: `attribute_not_exists(branch-key-id)`
+  - TableName: the configured Table Name
+- PUT:
+  - Item: A [record formatted item](#record-format) constructed from the active input
+  - ConditionExpression: `attribute_exists(branch-key-id)`
+  - TableName: the configured Table Name
+
+TransactWriteItemRequest:
+
+- TransactWriteItems: List of TransactWriteItem
+
+### GetEncryptedActiveBranchKey
+
+To get the active version for the branch key id from the keystore
+this operation MUST call AWS DDB `GetItem`
+using the `branch-key-id` as the Partition Key and `"branch:ACTIVE"` value as the Sort Key.
+
+The AWS DDB response MUST contain the fields defined in the [branch keystore record format](#record-format).
+The returned EncryptedHierarchicalKey MUST have the same identifier as the input.
+The returned EncryptedHierarchicalKey MUST have a type of ActiveHierarchicalSymmetricVersion.
+If the record does not contain the defined fields, this operation MUST fail.
+
+### GetEncryptedBranchKeyVersion
+
+To get a branch key from the keystore this operation MUST call AWS DDB `GetItem`
+using the `branch-key-id` as the Partition Key and "branch:version:" + `branchKeyVersion` value as the Sort Key.
+
+The AWS DDB response MUST contain the fields defined in the [branch keystore record format](#record-format).
+The returned EncryptedHierarchicalKey MUST have the same identifier as the input.
+The returned EncryptedHierarchicalKey MUST have the same version as the input.
+The returned EncryptedHierarchicalKey MUST have a type of HierarchicalSymmetricVersion.
+If the record does not contain the defined fields, this operation MUST fail.
+
+### GetEncryptedBeaconKey
+
+To get a branch key from the keystore this operation MUST call AWS DDB `GetItem`
+using the `branch-key-id` as the Partition Key and "beacon:ACTIVE" value as the Sort Key.
+
+The AWS DDB response MUST contain the fields defined in the [branch keystore record format](#record-format).
+The returned EncryptedHierarchicalKey MUST have the same identifier as the input.
+The returned EncryptedHierarchicalKey MUST have a type of ActiveHierarchicalSymmetricBeacon.
+If the record does not contain the defined fields, this operation MUST fail.
+
+## Record Format
+
+A branch key record MUST include the following key-value pairs:
+
+1. `branch-key-id` : Unique identifier for a branch key; represented as [AWS DDB String](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes)
+1. `type` : One of the following; represented as [AWS DDB String](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes)
+   - The string literal `"beacon:ACTIVE"`. Then `enc` is the wrapped beacon key.
+   - The string `"branch:version:"` + `version`, where `version` is the Branch Key Version. Then `enc` is the wrapped branch key.
+   - The string literal `"branch:ACTIVE"`. Then `enc` is the wrapped beacon key of the active version. Then
+1. `version` : Only exists if `type` is the string literal `"branch:ACTIVE"`.
+   Then it is the Branch Key Version. represented as [AWS DDB String](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes)
+1. `enc` : Encrypted version of the key;
+   represented as [AWS DDB Binary](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes)
+1. `kms-arn`: The AWS KMS Key ARN used to generate the `enc` value.
+   represented as [AWS DDB String](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes)
+1. `create-time`: Timestamp in ISO 8601 format in UTC, to microsecond precision.
+   Represented as [AWS DDB String](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes)
+1. `hierarchy-version`: Version of the hierarchical keyring;
+   represented as [AWS DDB Number](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes)
+
+A branch key record MAY include [custom encryption context](../branch-key-store.md#custom-encryption-context) key-value pairs.
+These attributes should be prefixed with `aws-crypto-ec:` the same way they are for [AWS KMS encryption context](../branch-key-store.md#encryption-context).

--- a/framework/key-store/encrypted-key-store.md
+++ b/framework/key-store/encrypted-key-store.md
@@ -1,0 +1,112 @@
+[//]: # "Copyright Amazon.com Inc. or its affiliates. All Rights Reserved."
+[//]: # "SPDX-License-Identifier: CC-BY-SA-4.0"
+
+# Encrypted Key Store Interface
+
+## Version
+
+0.1.0
+
+### Changelog
+
+- 0.1.0
+  - Initial record
+
+## Implementations
+
+| Language | Confirmed Compatible with Spec Version | Minimum Version Confirmed | Implementation |
+| -------- | -------------------------------------- | ------------------------- | -------------- |
+
+## Overview
+
+This is a custom interface for customers to construct their own storage layer for the [key store](../branch-key-store.md#overview).
+This is useful to either customize how DynamoDB is used or stored,
+or to implement a custom storage system such as S3,
+or to consolidate keystore data access behind some remote micro-service.
+
+The encrypted key store interface is not responsible for making sure that the encrypted keys are of the appropriate types.
+This is the responsibility of the wrapping key store.
+
+## Definitions
+
+### Conventions used in this document
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL"
+in this document are to be interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
+
+### EncryptedHierarchicalKey
+
+An encrypted structure that holds an encrypted beacon or branch key.
+
+This structure MUST include all of the following fields:
+
+- [BranchKeyId](./structures.md#branch-key-id)
+- [Type](#type)
+- CreateTime: Timestamp in ISO 8601 format in UTC, to microsecond precision.
+- KmsArn: The AWS KMS Key ARN used to protect the CiphertextBlob value.
+- [EncryptionContext](./structures.md#encryption-context-3)
+- CiphertextBlob: The encrypted binary for the hierarchical key.
+
+### Type
+
+A union that MUST hold the following three options
+
+- ActiveHierarchicalSymmetricVersion [HierarchicalSymmetricVersion](#hierarchicalsymmetricversion)
+- HierarchicalSymmetricVersion [HierarchicalSymmetricVersion](#hierarchicalsymmetricversion)
+- ActiveHierarchicalSymmetricBeacon
+
+### HierarchicalSymmetricVersion
+
+A structure that MUST have one member,
+the UTF8 Encoded value of the version of the branch key.
+
+## Interface
+
+The EncryptedKeyStore MUST support the following operations:
+
+- [WriteNewKeyToStore](#writenewkeytostore)
+- [WriteNewBranchKeyVersionToKeystore](#writenewbranchkeyversiontokeystore)
+- [GetEncryptedActiveBranchKey](#getencryptedactivebranchkey)
+- [GetEncryptedBranchKeyVersion](#getencryptedbranchkeyversion)
+- [GetEncryptedBeaconKey](#getencryptedbeaconkey)
+- [GetTableName](#gettablename)
+
+### WriteNewKeyToStore
+
+The WriteNewKeyToStore caller MUST provide:
+
+- An [EncryptedHierarchicalKey](#encryptedhierarchicalkey) with a [type](#type) of ActiveHierarchicalSymmetricVersion
+- An [EncryptedHierarchicalKey](#encryptedhierarchicalkey) with a [type](#type) of HierarchicalSymmetricVersion
+- An [EncryptedHierarchicalKey](#encryptedhierarchicalkey) with a [type](#type) of ActiveHierarchicalSymmetricBeacon
+
+All three keys need to be written together with an atomic transactional write.
+See the [default encrypted key store's write new key to store specification](./default-encrypted-key-store.md#writenewkeytostore) for more details about what storage properties are expected.
+
+### WriteNewBranchKeyVersionToKeystore
+
+The WriteNewBranchKeyVersionToKeystore caller MUST provide:
+
+- An [EncryptedHierarchicalKey](#encryptedhierarchicalkey) with a [type](#type) of ActiveHierarchicalSymmetricVersion
+- An [EncryptedHierarchicalKey](#encryptedhierarchicalkey) with a [type](#type) of HierarchicalSymmetricVersion
+
+Both keys need to be written together with a consistent transactional write.
+See [default encrypted key store's write new branch key version to store specification](./default-encrypted-key-store.md#writenewbranchkeyversiontokeystore) for more details about what storage properties are expected.
+
+### GetEncryptedActiveBranchKey
+
+The GetEncryptedActiveBranchKey caller MUST provide the same inputs as the [GetActiveBranchKey](../branch-key-store.md#getactivebranchkey) operation.
+It MUST return an [EncryptedHierarchicalKey](#encryptedhierarchicalkey).
+
+### GetEncryptedBranchKeyVersion
+
+The GetEncryptedBranchKeyVersion caller MUST provide the same inputs as the [GetBranchKeyVersion](../branch-key-store.md#getbranchkeyversion) operation.
+It MUST return an [EncryptedHierarchicalKey](#encryptedhierarchicalkey).
+
+### GetEncryptedBeaconKey
+
+The GetEncryptedBeaconKey caller MUST provide the same inputs as the [GetBeaconKey](../branch-key-store.md#getbeaconkey) operation.
+It MUST return an [EncryptedHierarchicalKey](#encryptedhierarchicalkey).
+
+### GetTableName
+
+It MUST return the physical table name.


### PR DESCRIPTION
The key store defaults to DDB.
But customers have asked for
other storage options.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Check any applicable:

- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.
