### PR TITLE
fix: Names and clarification

### DIFF
--- a/framework/key-store/key-storage.md
+++ b/framework/key-store/key-storage.md
@@ -51,11 +51,16 @@ This structure MUST include all of the following fields:
 
 A union that MUST hold the following three options
 
-- ActiveHierarchicalSymmetricVersion [HierarchicalSymmetricVersion](#hierarchicalsymmetricversion)
-- HierarchicalSymmetricVersion [HierarchicalSymmetricVersion](#hierarchicalsymmetricversion)
+- ActiveHierarchicalSymmetricVersion [ActiveHierarchicalSymmetric](#activehierarchicalsymmetric)
+- HierarchicalSymmetricVersion [HierarchicalSymmetric](#hierarchicalsymmetric)
 - ActiveHierarchicalSymmetricBeacon
 
-### HierarchicalSymmetricVersion
+### ActiveHierarchicalSymmetric
+
+A structure that MUST have one member,
+the UTF8 Encoded value of the version of the branch key.
+
+### HierarchicalSymmetric
 
 A structure that MUST have one member,
 the UTF8 Encoded value of the version of the branch key.

--- a/framework/structures.md
+++ b/framework/structures.md
@@ -404,7 +404,7 @@ This value MUST be a version 4 [UUID](https://www.ietf.org/rfc/rfc4122.txt).
 
 ##### Encryption Context
 
-The [custom encryption context](#encryption-context) associated with this branch key.
+The [encryption context](#encryption-context) associated with this branch key.
 
 ## Beacon Key Materials
 


### PR DESCRIPTION
The encyrption context on hierarchical materials
is all the encryption context,
not only any custom values set by the customer
on branch key creation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Check any applicable:

- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.
