### PR TITLE
fix: Update symmetric signing keys

### DIFF
--- a/framework/structures.md
+++ b/framework/structures.md
@@ -266,6 +266,9 @@ These keys are used to generate symmetric signatures during encryption.
 
 If the algorithm suite does not contain a symmetric signing algorithm, this list MUST NOT be included in the materials.
 If the algorithm suite does contain a symmetric signing algorithm, this list MUST have length equal to the [encrypted data key list](#encrypted-data-keys).
+Since the symmetric signing keys value is optional,
+if the [encrypted data key list](#encrypted-data-keys) is empty
+the symmetric signing algorithm MAY be omitted.
 
 The symmetric signature keys MUST adhere to the specification for [symmetric signature algorithms](./algorithm-suites.md#symmetric-signature-algorithm)
 included in this encryption material's [algorithm suite](#algorithm-suite).


### PR DESCRIPTION
0 and `null` are both OK.
This is how the Java type conversion
works for the MPL Dafny.

See: https://github.com/aws/aws-cryptographic-material-providers-library/pull/1328

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Check any applicable:

- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.
