### PR TITLE
chore: Update README.md with public Duvet link

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ run `./ci/prettify.sh check`.
 
 ## Generate Duvet Reports
 
-[Duvet](https://github.com/awslabs/aws-encryption-sdk-specification/issues/240) is a tool that can be used to ensure specification is documented alongside code.
+[Duvet](https://github.com/awslabs/duvet) is a tool that can be used to ensure specification is documented alongside code.
 
 This repo contains helpful scripts for installing and using Duvet with this specification.
 


### PR DESCRIPTION
_Issue #, if available:_ https://github.com/awslabs/aws-encryption-sdk-specification/issues/240

_Description of changes:_ Duvet is public. Update README to reflect this. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Check any applicable:

- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.
