### PR TITLE
chore: encryption-context changes

### DIFF
--- a/framework/branch-key-store.md
+++ b/framework/branch-key-store.md
@@ -745,13 +745,14 @@ The Branch Key Context:
 
 - MUST have a `branch-key-id` key who's value MUST not be an empty string
 - MUST have a `type` key who's value MUST not be an empty string
-- MUST have a `create-time` key in ISO 8601 format in UTC
+- MUST have a `create-time` key with a value in ISO 8601 format in UTC
 - MUST have a `tablename` key who's value is the logicalKeyStoreName
 - MUST have a `kms-arn` key who's value is valid KMS ARN
 - MUST have a `hierarchy-version` key who's value is either "1" or "2"
 - MUST NOT have a `enc` key
 - MAY have one or more keys prefixed with `aws-crypto-ec:` which is the encyption context send by the customer.
   The `aws-crypto-ec:` prefix is prepended by the library
+- MUST NOT have any other keys apart from the ones mentioned above if `hierarchy-version` is "2"
 
 ### ACTIVE Branch Key Context
 

--- a/framework/branch-key-store.md
+++ b/framework/branch-key-store.md
@@ -518,7 +518,7 @@ List of TransactWriteItem:
     - “create-time” (S): `timestamp`
     - "kms-arn" (S): configured KMS Key
     - “hierarchy-version” (N): either `1` or `2`, depending on the `hierarchy-version`
-    - Every key-value pair of the [encryption context](#encryption-context) that is associated with the branch key
+    - Every key-value pair of the [encryption context](./structures.md#encryption-context) that is associated with the branch key
       MUST be added with an Attribute Name of `aws-crypto-ec:` + the Key and Attribute Value (S) of the value.
   - ConditionExpression: `attribute_not_exists(branch-key-id)`
   - TableName: the configured Table Name
@@ -530,7 +530,7 @@ List of TransactWriteItem:
     - “create-time” (S): `timestamp`
     - "kms-arn" (S): configured KMS Key
     - “hierarchy-version” (N): either `1` or `2`, depending on the `hierarchy-version`
-    - Every key-value pair of the custom [encryption context](#encryption-context) that is associated with the branch key
+    - Every key-value pair of the custom [encryption context](./structures.md#encryption-context) that is associated with the branch key
       MUST be added with an Attribute Name of `aws-crypto-ec:` + the Key and Attribute Value (S) of the value.
   - ConditionExpression: `attribute_not_exists(branch-key-id)`
   - TableName: the configured Table Name
@@ -542,7 +542,7 @@ List of TransactWriteItem:
     - “create-time” (S): `timestamp`
     - "kms-arn" (S): configured KMS Key
     - “hierarchy-version” (N): either `1` or `2`, depending on the `hierarchy-version`
-    - Every key-value pair of the custom [encryption context](#encryption-context) that is associated with the branch key
+    - Every key-value pair of the custom [encryption context](./structures.md#encryption-context) that is associated with the branch key
       MUST be added with an Attribute Name of `aws-crypto-ec:` + the Key and Attribute Value (S) of the value.
   - ConditionExpression: `attribute_not_exists(branch-key-id)`
   - TableName is the configured Table Name
@@ -624,18 +624,18 @@ Otherwise, this operation MUST yield an error.
 The operation MUST use the configured `KMS SDK Client` to authenticate the value of the keystore item.
 
 This operation MUST call AWS DDB `GetItem`.
-Every attribute except `enc` on the AWS DDB response item MUST be converted to a set of key value pairs (a Map)
-which is the [AWS KMS Encryption Context](#aws-kms-encryption-context).
+Every attribute except `enc` on the AWS DDB response item MUST be converted to a set of key value pairs
+which is the [branch key context](#branch-key-context).
 
 The operation MUST call [AWS KMS API ReEncrypt](https://docs.aws.amazon.com/kms/latest/APIReference/API_ReEncrypt.html)
 with a request constructed as follows:
 
-- `SourceEncryptionContext` MUST be the [AWS KMS Encryption Context](#aws-kms-encryption-context) constructed above
+- `SourceEncryptionContext` MUST be the [branch key context](#branch-key-context) constructed above
 - `SourceKeyId` MUST be [compatible with](#aws-key-arn-compatibility) the configured KMS Key in the [AWS KMS Configuration](#aws-kms-configuration) for this keystore.
 - `CiphertextBlob` MUST be the `enc` attribute value on the AWS DDB response item
 - `GrantTokens` MUST be the configured [grant tokens](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token).
 - `DestinationKeyId` MUST be [compatible with](#aws-key-arn-compatibility) the configured KMS Key in the [AWS KMS Configuration](#aws-kms-configuration) for this keystore.
-- `DestinationEncryptionContext` MUST be the [AWS KMS Encryption Context](#aws-kms-encryption-context) constructed above
+- `DestinationEncryptionContext` MUST be the [branch key context](#branch-key-context) constructed above
 
 #### Authenticating a Branch Keystore item for item with `hierarchy-version` v2
 
@@ -672,7 +672,7 @@ The operation MUST decrypt the branch key according to the [AWS KMS Branch Key D
 If the branch key fails to decrypt, GetActiveBranchKey MUST fail.
 
 This GetActiveBranchKey MUST construct [branch key materials](./structures.md#branch-key-materials)
-according to [Branch Key Materials From Authenticated Encryption Context](#branch-key-materials-from-authenticated-encryption-context).
+according to [Branch Key Materials From Authenticated Branch Key Context](#branch-key-materials-from-authenticated-branch-key-context).
 
 This operation MUST return the constructed [branch key materials](./structures.md#branch-key-materials).
 
@@ -698,7 +698,7 @@ The operation MUST decrypt the branch key according to the [AWS KMS Branch Key D
 If the branch key fails to decrypt, this operation MUST fail.
 
 This GetBranchKeyVersion MUST construct [branch key materials](./structures.md#branch-key-materials)
-according to [Branch Key Materials From Authenticated Encryption Context](#branch-key-materials-from-authenticated-encryption-context).
+according to [Branch Key Materials From Authenticated Branch Key Context](#branch-key-materials-from-authenticated-branch-key-context).
 
 This operation MUST return the constructed [branch key materials](./structures.md#branch-key-materials).
 
@@ -773,13 +773,13 @@ The Beacon key branch key context MUST NOT have a `version` key.
 ## AWS KMS Encryption Context
 
 If the `hierarchy-version` is v1, AWS KMS encryption context MUST be same as [branch key context](#branch-key-context).
-If the `hierarchy-version` is v2, AWS KMS encryption context MUST be the [encryption context](../structures.md#encryption-context) send by users without any transformation. This requirement applies regardless of the Branch Key Item's `type`.
+If the `hierarchy-version` is v2, AWS KMS encryption context MUST be the [encryption context](./structures.md#encryption-context) send by users without any transformation. This requirement applies regardless of the Branch Key Item's `type`.
 
 ## Custom Encryption Context
 
 If [encryption context](./structures.md#encryption-context)
 is associated with the branch key these values MUST be added to the AWS KMS encryption context.
-To avoid name collisions each added attribute from the [encryption context](./structures.md#encryption-context-3)
+To avoid name collisions each added attribute from the [encryption context](./structures.md#encryption-context)
 MUST be prefixed with `aws-crypto-ec:`.
 Across all versions of a Branch Key, the encryption context MUST be equal.
 
@@ -847,7 +847,7 @@ A branch key record MUST include the following key-value pairs:
 1. `hierarchy-version`: Version of the hierarchical keyring;
    represented as [AWS DDB Number](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes)
 
-A branch key record MAY include [encryption context](#encryption-context) key-value pairs.
+A branch key record MAY include [encryption context](./structures.md#encryption-context) key-value pairs.
 These attributes MUST be always prefixed with `aws-crypto-ec:` regardless of the item's `hierarchy-version`.
 
 ### Branch Key Materials From Authenticated Branch key Context
@@ -871,7 +871,7 @@ To construct [branch key materials](./structures.md#branch-key-materials) from a
 
 ### Encryption Context From Authenticated Branch Key Context
 
-The encryption context](./structures.md#encryption-context) is stored as map of UTF8 Encoded bytes.
+The [encryption context](./structures.md#encryption-context) is stored as map of UTF8 Encoded bytes.
 
 For every key in the [encryption context](./structures.md#encryption-context)
 the string `aws-crypto-ec:` + the UTF8 decode of this key

--- a/framework/branch-key-store.md
+++ b/framework/branch-key-store.md
@@ -358,7 +358,7 @@ The operation MUST call AWS KMS GenerateDataKeyWithoutPlaintext with a request c
 
 - `KeyId` MUST be the configured `AWS KMS Key ARN` in the [AWS KMS Configuration](#aws-kms-configuration) for this keystore.
 - `NumberOfBytes` MUST be 32.
-- `EncryptionContext` MUST be the [encryption context for beacon keys](#beacon-key-encryption-context).
+- `EncryptionContext` MUST be the [branch key context for beacon keys](#beacon-branch-key-context).
 - `GrantTokens` MUST be this keystore's [grant tokens](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token).
 
 If the call to AWS KMS GenerateDataKeyWithoutPlaintext succeeds,
@@ -405,11 +405,11 @@ as the wrapped Beacon Key.
 #### Wrapped Branch Key Creation `v1`
 
 The operation MUST generate a map of strings,
-the [DECRYPT_ONLY encryption context for branch keys](#decrypt_only-encryption-context),
+the [DECRYPT_ONLY branch context for branch keys](#decrypt_only-branch-key-context),
 using the `branchKeyId`, `version`, `timestamp`, `kms-arn`, `encryption-context`, and `hierarchy-version`.
 
 The operation MUST generate a map of strings,
-the [ACTIVE encryption context for branch keys](#active-encryption-context)
+the [ACTIVE branch context for branch keys](#active-branch-key-context)
 using the `branchKeyId`, `version`, `timestamp`, `kms-arn`, `encryption-context`, and `hierarchy-version`.
 
 The operation MUST call [AWS KMS API GenerateDataKeyWithoutPlaintext](https://docs.aws.amazon.com/kms/latest/APIReference/API_GenerateDataKeyWithoutPlaintext.html).
@@ -418,7 +418,7 @@ The operation MUST call AWS KMS GenerateDataKeyWithoutPlaintext with a request c
 
 - `KeyId` MUST be the configured `AWS KMS Key ARN` in the [AWS KMS Configuration](#aws-kms-configuration) for this keystore.
 - `NumberOfBytes` MUST be 32.
-- `EncryptionContext` MUST be the [DECRYPT_ONLY encryption context for branch keys](#decrypt_only-encryption-context).
+- `EncryptionContext` MUST be the [DECRYPT_ONLY branch context for branch keys](#decrypt_only-branch-key-context).
 - `GrantTokens` MUST be this keystore's [grant tokens](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token).
 
 If the call to AWS KMS GenerateDataKeyWithoutPlaintext succeeds,
@@ -428,12 +428,12 @@ as the wrapped DECRYPT_ONLY Branch Key.
 The operation MUST call [AWS KMS API ReEncrypt](https://docs.aws.amazon.com/kms/latest/APIReference/API_ReEncrypt.html)
 with a request constructed as follows:
 
-- `SourceEncryptionContext` MUST be the [DECRYPT_ONLY encryption context for branch keys](#decrypt_only-encryption-context).
+- `SourceEncryptionContext` MUST be the [DECRYPT_ONLY branch key context for branch keys](#decrypt_only-branch-key-context).
 - `SourceKeyId` MUST be the `kms-arn`.
 - `CiphertextBlob` MUST be the wrapped DECRYPT_ONLY Branch Key.
 - `GrantTokens` MUST be this keystore's [grant tokens](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token).
 - `DestinationKeyId` MUST be the `kms-arn`.
-- `DestinationEncryptionContext` MUST be the [ACTIVE encryption context for branch keys](#active-encryption-context).
+- `DestinationEncryptionContext` MUST be the [ACTIVE branch key context for branch keys](#active-branch-key-context).
 
 If the call to AWS KMS ReEncrypt succeeds,
 the operation MUST use the ReEncrypt result `CiphertextBlob`
@@ -518,7 +518,7 @@ List of TransactWriteItem:
     - “create-time” (S): `timestamp`
     - "kms-arn" (S): configured KMS Key
     - “hierarchy-version” (N): either `1` or `2`, depending on the `hierarchy-version`
-    - Every key-value pair of the custom [encryption context](./structures.md#encryption-context-3) that is associated with the branch key
+    - Every key-value pair of the [encryption context](#encryption-context) that is associated with the branch key
       MUST be added with an Attribute Name of `aws-crypto-ec:` + the Key and Attribute Value (S) of the value.
   - ConditionExpression: `attribute_not_exists(branch-key-id)`
   - TableName: the configured Table Name
@@ -530,7 +530,7 @@ List of TransactWriteItem:
     - “create-time” (S): `timestamp`
     - "kms-arn" (S): configured KMS Key
     - “hierarchy-version” (N): either `1` or `2`, depending on the `hierarchy-version`
-    - Every key-value pair of the custom [encryption context](./structures.md#encryption-context-3) that is associated with the branch key
+    - Every key-value pair of the custom [encryption context](#encryption-context) that is associated with the branch key
       MUST be added with an Attribute Name of `aws-crypto-ec:` + the Key and Attribute Value (S) of the value.
   - ConditionExpression: `attribute_not_exists(branch-key-id)`
   - TableName: the configured Table Name
@@ -542,7 +542,7 @@ List of TransactWriteItem:
     - “create-time” (S): `timestamp`
     - "kms-arn" (S): configured KMS Key
     - “hierarchy-version” (N): either `1` or `2`, depending on the `hierarchy-version`
-    - Every key-value pair of the custom [encryption context](./structures.md#encryption-context-3) that is associated with the branch key
+    - Every key-value pair of the custom [encryption context](#encryption-context) that is associated with the branch key
       MUST be added with an Attribute Name of `aws-crypto-ec:` + the Key and Attribute Value (S) of the value.
   - ConditionExpression: `attribute_not_exists(branch-key-id)`
   - TableName is the configured Table Name
@@ -625,25 +625,25 @@ The operation MUST use the configured `KMS SDK Client` to authenticate the value
 
 This operation MUST call AWS DDB `GetItem`.
 Every attribute except `enc` on the AWS DDB response item MUST be converted to a set of key value pairs (a Map)
-which is the [encryption context](#encryption-context).
+which is the [AWS KMS Encryption Context](#aws-kms-encryption-context).
 
 The operation MUST call [AWS KMS API ReEncrypt](https://docs.aws.amazon.com/kms/latest/APIReference/API_ReEncrypt.html)
 with a request constructed as follows:
 
-- `SourceEncryptionContext` MUST be the [encryption context](#encryption-context) constructed above
+- `SourceEncryptionContext` MUST be the [AWS KMS Encryption Context](#aws-kms-encryption-context) constructed above
 - `SourceKeyId` MUST be [compatible with](#aws-key-arn-compatibility) the configured KMS Key in the [AWS KMS Configuration](#aws-kms-configuration) for this keystore.
 - `CiphertextBlob` MUST be the `enc` attribute value on the AWS DDB response item
 - `GrantTokens` MUST be the configured [grant tokens](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token).
 - `DestinationKeyId` MUST be [compatible with](#aws-key-arn-compatibility) the configured KMS Key in the [AWS KMS Configuration](#aws-kms-configuration) for this keystore.
-- `DestinationEncryptionContext` MUST be the [encryption context](#encryption-context) constructed above
+- `DestinationEncryptionContext` MUST be the [AWS KMS Encryption Context](#aws-kms-encryption-context) constructed above
 
 #### Authenticating a Branch Keystore item for item with `hierarchy-version` v2
 
 The operation MUST use the configured `KMS SDK Client` to authenticate the value of the keystore item.
 
 This operation MUST call AWS DDB `GetItem`.
-Every attribute except `enc` on the AWS DDB response item MUST be converted to a set of key value pairs (a Map)
-which is the [branch key context](#branch-key-context). The [encryption context](#encryption-context) MUST be built from branch key context by extracting keys with prefix `aws-crypto-ec:` and then dropping the prefix.
+Every attribute except `enc` on the AWS DDB response item MUST be converted to a set of key value pairs
+which is the [branch key context](#branch-key-context). The [AWS KMS Encryption Context](#aws-kms-encryption-context) MUST be built from branch key context by extracting keys with prefix `aws-crypto-ec:` and then dropping the prefix.
 
 The operation MUST follow [AWS KMS Branch Key Decryption](#aws-kms-branch-key-decryption) to decrypt and authentication the branch key context.
 
@@ -770,34 +770,18 @@ In addition to the [branch key context](#branch-key-context):
 The Beacon key branch key context MUST includes a key `type` and the value MUST be `"beacon:ACTIVE"`.
 The Beacon key branch key context MUST NOT have a `version` key.
 
-## Encryption Context
-
-This section describes how the AWS KMS encryption context is built.
+## AWS KMS Encryption Context
 
 If the `hierarchy-version` is v1, AWS KMS encryption context MUST be same as [branch key context](#branch-key-context).
-If the `hierarchy-version` is v2, AWS KMS encryption context MUST be the [encryption context](../structures.md#encryption-context) send by users without any transformation.
+If the `hierarchy-version` is v2, AWS KMS encryption context MUST be the [encryption context](../structures.md#encryption-context) send by users without any transformation. This requirement applies regardless of the Branch Key Item's `type`.
 
-If the `hierarchy-version` is v2, the encryption context send to AWS KMS MUST always match the encryption context originally sent by the user, without any variations. This requirement applies regardless of the type of encryption context being used, whether it is the ACTIVE encryption context, the DECRYPT_ONLY encryption context, the Beacon Key encryption context, or a custom encryption context.
+## Custom Encryption Context
 
-### ACTIVE Encryption Context
-
-If the `hierarchy-version` is v1, ACTIVE Encryption Context is same as [ACTIVE Branch Key Context](#active-branch-key-context)
-
-### DECRYPT_ONLY Encryption Context
-
-If the `hierarchy-version` is v1, DECRYPT_ONLY Encryption Context is same as [DECRYPT_ONLY Branch Key Context](#decrypt_only-branch-key-context)
-
-### Beacon Key Encryption Context
-
-If the `hierarchy-version` is v1, Beacon Encryption Context is same as [Beacon Key Branch Key Context](#beacon-key-branch-key-context)
-
-### Custom Encryption Context
-
-If custom [encryption context](./structures.md#encryption-context)
+If [encryption context](./structures.md#encryption-context)
 is associated with the branch key these values MUST be added to the AWS KMS encryption context.
-To avoid name collisions each added attribute from the custom [encryption context](./structures.md#encryption-context-3)
+To avoid name collisions each added attribute from the [encryption context](./structures.md#encryption-context-3)
 MUST be prefixed with `aws-crypto-ec:`.
-Across all versions of a Branch Key, the custom encryption context MUST be equal.
+Across all versions of a Branch Key, the encryption context MUST be equal.
 
 ## AWS KMS Branch Key Decryption
 
@@ -806,13 +790,13 @@ The operation MUST use the configured `KMS SDK Client` to decrypt the value of t
 Every attribute except for `enc` on the AWS DDB response item
 MUST be authenticated in the decryption of `enc`
 
-Every key in the constructed [encryption context](#encryption-context)
+Every key in the constructed [branch key context](#branch-key-context)
 except `tableName`
 MUST exist as a string attribute in the AWS DDB response item.
-Every value in the constructed [encryption context](#encryption-context)
+Every value in the constructed [branch key context](#branch-key-context)
 except the logical table name
 MUST equal the value with the same key in the AWS DDB response item.
-The key `enc` MUST NOT exist in the constructed [encryption context](#encryption-context).
+The key `enc` MUST NOT exist in the constructed [branch key context](#branch-key-context).
 
 If the Keystore's [AWS KMS Configuration](#aws-kms-configuration) is `KMS Key ARN` or `KMS MRKey ARN`,
 the `kms-arn` field of the DDB response item MUST be
@@ -833,7 +817,7 @@ the keystore operation MUST call with a request constructed as follows:
   If the KMS Configuration is MRDiscovery, `KeyId` MUST be the `kms-arn` attribute value of the AWS DDB response item, with the region replaced by the configured region.
   Otherwise, it MUST BE the Keystore's configured KMS Key.
 - `CiphertextBlob` MUST be the `enc` attribute value on the AWS DDB response item
-- `EncryptionContext` MUST be the [encryption context](#encryption-context) constructed above
+- `EncryptionContext` MUST be the [AWS KMS Encryption Context](#aws-kms-encryption-context) constructed above
 - `GrantTokens` MUST be this keystore's [grant tokens](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token).
 
 Every attribute except for `enc` on the AWS DDB response item
@@ -863,19 +847,19 @@ A branch key record MUST include the following key-value pairs:
 1. `hierarchy-version`: Version of the hierarchical keyring;
    represented as [AWS DDB Number](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes)
 
-A branch key record MAY include [custom encryption context](#custom-encryption-context) key-value pairs.
+A branch key record MAY include [encryption context](#encryption-context) key-value pairs.
 These attributes MUST be always prefixed with `aws-crypto-ec:` regardless of the item's `hierarchy-version`.
 
-### Branch Key Materials From Authenticated Encryption Context
+### Branch Key Materials From Authenticated Branch key Context
 
 The `type` attribute MUST either be equal to `"branch:ACTIVE"` or start with `"branch:version:"`.
 
 If the `type` attribute is equal to `"branch:ACTIVE"`
-then the authenticated encryption context MUST have a `version` attribute
+then the authenticated branch key context MUST have a `version` attribute
 and the version string is this value.
 If the `type` attribute start with `"branch:version:"` then the version string MUST be equal to this value.
 
-To construct [branch key materials](./structures.md#branch-key-materials) from authenticated encryption context as follows:
+To construct [branch key materials](./structures.md#branch-key-materials) from authenticated branch key context as follows:
 
 - [Branch Key](./structures.md#branch-key) MUST be the [decrypted branch key material](#aws-kms-branch-key-decryption)
 - [Branch Key Id](./structures.md#branch-key-id) MUST be the `branch-key-id`
@@ -883,16 +867,16 @@ To construct [branch key materials](./structures.md#branch-key-materials) from a
   The version string MUST start with `branch:version:`.
   The remaining string encoded as UTF8 bytes MUST be the Branch Key version.
 - [Encryption Context](./structures.md#encryption-context-3) MUST be constructed by
-  [Custom Encryption Context From Authenticated Encryption Context](#custom-encryption-context-from-authenticated-encryption-context)
+  [Encryption Context From Authenticated Branch Key Context](#encryption-context-from-authenticated-branch-key-context)
 
-### Custom Encryption Context From Authenticated Encryption Context
+### Encryption Context From Authenticated Branch Key Context
 
-The custom encryption context is stored as map of UTF8 Encoded bytes.
+The encryption context](./structures.md#encryption-context) is stored as map of UTF8 Encoded bytes.
 
-For every key in the [encryption context](./structures.md#encryption-context-3)
+For every key in the [encryption context](./structures.md#encryption-context)
 the string `aws-crypto-ec:` + the UTF8 decode of this key
 MUST exist as a key in the authenticated encryption context.
-Also, the value in the [encryption context](./structures.md#encryption-context-3) for this key
+Also, the value in the [encryption context](./structures.md#encryption-context) for this key
 MUST equal the value in the authenticated encryption context
 for the constructed key.
 

--- a/framework/branch-key-store.md
+++ b/framework/branch-key-store.md
@@ -518,7 +518,7 @@ List of TransactWriteItem:
     - “create-time” (S): `timestamp`
     - "kms-arn" (S): configured KMS Key
     - “hierarchy-version” (N): either `1` or `2`, depending on the `hierarchy-version`
-    - Every key-value pair of the [encryption context](./structures.md#encryption-context) that is associated with the branch key
+    - Every key-value pair in the [encryption context](./structures.md#encryption-context) provided by users and is associated with the branch key
       MUST be added with an Attribute Name of `aws-crypto-ec:` + the Key and Attribute Value (S) of the value.
   - ConditionExpression: `attribute_not_exists(branch-key-id)`
   - TableName: the configured Table Name
@@ -530,7 +530,7 @@ List of TransactWriteItem:
     - “create-time” (S): `timestamp`
     - "kms-arn" (S): configured KMS Key
     - “hierarchy-version” (N): either `1` or `2`, depending on the `hierarchy-version`
-    - Every key-value pair of the custom [encryption context](./structures.md#encryption-context) that is associated with the branch key
+    - Every key-value pair in the [encryption context](./structures.md#encryption-context) provided by users and is associated with the branch key
       MUST be added with an Attribute Name of `aws-crypto-ec:` + the Key and Attribute Value (S) of the value.
   - ConditionExpression: `attribute_not_exists(branch-key-id)`
   - TableName: the configured Table Name
@@ -542,7 +542,7 @@ List of TransactWriteItem:
     - “create-time” (S): `timestamp`
     - "kms-arn" (S): configured KMS Key
     - “hierarchy-version” (N): either `1` or `2`, depending on the `hierarchy-version`
-    - Every key-value pair of the custom [encryption context](./structures.md#encryption-context) that is associated with the branch key
+    - Every key-value pair in the [encryption context](./structures.md#encryption-context) provided by users and is associated with the branch key
       MUST be added with an Attribute Name of `aws-crypto-ec:` + the Key and Attribute Value (S) of the value.
   - ConditionExpression: `attribute_not_exists(branch-key-id)`
   - TableName is the configured Table Name
@@ -594,8 +594,8 @@ List of TransactWriteItem:
     - “enc” (B): the wrapped DECRYPT_ONLY Branch Key `CiphertextBlob` from the KMS operation
     - “create-time” (S): `timestamp`
     - "kms-arn" (S): configured KMS Key
-    - “hierarchy-version” (N): 1
-    - Every key-value pair of the custom [encryption context](./structures.md#encryption-context-3) that is associated with the branch key
+    - “hierarchy-version” (N): either `1` or `2`, depending on the `hierarchy-version`
+    - Every key-value pair in the [encryption context](./structures.md#encryption-context) provided by users and is associated with the branch key
       MUST be added with an Attribute Name of `aws-crypto-ec:` + the Key and Attribute Value (S) of the value.
   - ConditionExpression: `attribute_not_exists(branch-key-id)`
   - TableName: the configured Table Name
@@ -606,8 +606,8 @@ List of TransactWriteItem:
     - “enc” (B): wrapped ACTIVE Branch Key `CiphertextBlob` from the KMS operation
     - “create-time” (S): `timestamp`
     - "kms-arn" (S): configured KMS Key
-    - “hierarchy-version” (N): 1
-    - Every key-value pair of the custom [encryption context](./structures.md#encryption-context-3) that is associated with the branch key
+    - “hierarchy-version” (N): either `1` or `2`, depending on the `hierarchy-version`
+    - Every key-value pair in the [encryption context](./structures.md#encryption-context) provided by users and is associated with the branch key
       MUST be added with an Attribute Name of `aws-crypto-ec:` + the Key and Attribute Value (S) of the value.
   - ConditionExpression: `attribute_exists(branch-key-id)`
   - TableName: the configured Table Name
@@ -774,14 +774,6 @@ The Beacon key branch key context MUST NOT have a `version` key.
 
 If the `hierarchy-version` is v1, AWS KMS encryption context MUST be same as [branch key context](#branch-key-context).
 If the `hierarchy-version` is v2, AWS KMS encryption context MUST be the [encryption context](./structures.md#encryption-context) send by users without any transformation. This requirement applies regardless of the Branch Key Item's `type`.
-
-## Custom Encryption Context
-
-If [encryption context](./structures.md#encryption-context)
-is associated with the branch key these values MUST be added to the AWS KMS encryption context.
-To avoid name collisions each added attribute from the [encryption context](./structures.md#encryption-context)
-MUST be prefixed with `aws-crypto-ec:`.
-Across all versions of a Branch Key, the encryption context MUST be equal.
 
 ## AWS KMS Branch Key Decryption
 

--- a/framework/branch-key-store.md
+++ b/framework/branch-key-store.md
@@ -795,8 +795,8 @@ MUST be authenticated in the decryption of `enc`
 
 Every key in the constructed [branch key context](#branch-key-context)
 except `tableName`
-MUST exist as a attribute in the AWS DDB response item. 
-All attributes in the AWS DynamoDB response item MUST be of type string, 
+MUST exist as a attribute in the AWS DDB response item.
+All attributes in the AWS DynamoDB response item MUST be of type string,
 with the exception of hierarchy-version, which MUST be of type number.
 Every value in the constructed [branch key context](#branch-key-context)
 except the logical table name

--- a/framework/branch-key-store.md
+++ b/framework/branch-key-store.md
@@ -650,8 +650,8 @@ The operation MUST use the configured `KMS SDK Client` to authenticate the value
 
 This operation MUST call AWS DDB `GetItem`.
 Every attribute except `enc` on the AWS DDB response item MUST be converted to a set of key value pairs (a Map)
-which is the [branch key context](#branch-key-context). 
-Every key in the constructed branch key context except tableName MUST exist as a string attribute in the AWS DDB response item. 
+which is the [branch key context](#branch-key-context).
+Every key in the constructed branch key context except tableName MUST exist as a string attribute in the AWS DDB response item.
 The [AWS KMS Encryption Context](#aws-kms-encryption-context) MUST be built from branch key context by extracting keys with prefix `aws-crypto-ec:` and then dropping the prefix.
 
 The operation MUST follow [AWS KMS Branch Key Decryption](#aws-kms-branch-key-decryption) to decrypt and authentication the branch key context.

--- a/framework/branch-key-store.md
+++ b/framework/branch-key-store.md
@@ -847,7 +847,7 @@ A branch key record MUST include the following key-value pairs:
    represented as [AWS DDB Number](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes)
 
 A branch key record MAY include [encryption context](./structures.md#encryption-context) key-value pairs.
-These attributes MUST be always prefixed with `aws-crypto-ec:` regardless of the item's `hierarchy-version`.
+These attributes MUST be prefixed with `aws-crypto-ec:` regardless of the item's `hierarchy-version`.
 
 ### Branch Key Materials From Authenticated Branch key Context
 

--- a/framework/branch-key-store.md
+++ b/framework/branch-key-store.md
@@ -340,7 +340,7 @@ Otherwise, this operation MUST yield an error.
 To create a branch key, this operation MUST take the following:
 
 - `branchKeyId`: The identifier
-- `encryptionContext`: Additional encryption context to bind to the created keys
+- `encryption-context`: Additional encryption context to bind to the created keys
 - `hierarchy-version`: The hierarchy-version determined by the input
 
 If the `hierarchy-version` is `v1`,

--- a/framework/structures.md
+++ b/framework/structures.md
@@ -414,7 +414,7 @@ This value MUST be a version 4 [UUID](https://www.ietf.org/rfc/rfc4122.txt).
 
 ##### Encryption Context
 
-The [encryption context](./structures.md#encryption-context) is a key-value pair provided by users and is associated with the branch key. 
+The [encryption context](./structures.md#encryption-context) is a key-value pair provided by users and is associated with the branch key.
 The key of this encryption context is alway prepended with `aws-crypto-ec:`.
 
 ##### KMS ARN

--- a/framework/structures.md
+++ b/framework/structures.md
@@ -414,7 +414,8 @@ This value MUST be a version 4 [UUID](https://www.ietf.org/rfc/rfc4122.txt).
 
 ##### Encryption Context
 
-The [custom encryption context](#encryption-context) associated with this branch key.
+The [encryption context](./structures.md#encryption-context) is a key-value pair provided by users and is associated with the branch key. 
+The key of this encryption context is alway prepended with `aws-crypto-ec:`.
 
 ##### KMS ARN
 

--- a/framework/structures.md
+++ b/framework/structures.md
@@ -127,7 +127,7 @@ an identifier into a key store that will return the plaintext data key.
 #### Structure
 
 The encryption context is a key-value mapping of arbitrary, non-secret, UTF-8 encoded strings.
-It is used by the user during [encryption](../client-apis/encrypt.md), [decryption](../client-apis/decrypt.md) and [createKey](branch-key-store.md#createkey) to provide additional authenticated data (AAD).
+It is used during [encryption](../client-apis/encrypt.md) and [decryption](../client-apis/decrypt.md) to provide additional authenticated data (AAD).
 
 Users SHOULD use the encryption context to store:
 

--- a/framework/structures.md
+++ b/framework/structures.md
@@ -414,8 +414,7 @@ This value MUST be a version 4 [UUID](https://www.ietf.org/rfc/rfc4122.txt).
 
 ##### Encryption Context
 
-The [encryption context](./structures.md#encryption-context) is a key-value pair provided by users and is associated with the branch key.
-The key of this encryption context is alway prepended with `aws-crypto-ec:`.
+The [encryption context](./structures.md#encryption-context) associated with all the items of this Branch Key.
 
 ##### KMS ARN
 
@@ -468,7 +467,7 @@ the beacon key can be discarded.
 
 ##### Encryption Context
 
-The [encryption context](#encryption-context) associated with this beacon key.
+The [encryption context](./structures.md#encryption-context) is a key-value pair provided by users and is associated with the beacon key.
 
 ##### KMS ARN
 

--- a/framework/structures.md
+++ b/framework/structures.md
@@ -468,7 +468,7 @@ the beacon key can be discarded.
 
 ##### Encryption Context
 
-The [custom encryption context](#encryption-context) associated with this beacon key.
+The [encryption context](#encryption-context) associated with this beacon key.
 
 ##### KMS ARN
 

--- a/framework/structures.md
+++ b/framework/structures.md
@@ -127,7 +127,7 @@ an identifier into a key store that will return the plaintext data key.
 #### Structure
 
 The encryption context is a key-value mapping of arbitrary, non-secret, UTF-8 encoded strings.
-It is used during [encryption](../client-apis/encrypt.md) and [decryption](../client-apis/decrypt.md) to provide additional authenticated data (AAD).
+It is used by the user during [encryption](../client-apis/encrypt.md), [decryption](../client-apis/decrypt.md) and [createKey](branch-key-store.md#createkey) to provide additional authenticated data (AAD).
 
 Users SHOULD use the encryption context to store:
 


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
This PR is getting merged to `rishav/hv-2-spec`. This PR addresses comments in [PR 300](https://github.com/awslabs/aws-encryption-sdk-specification/pull/300) that is related to encryption context only. 

Note: If `encryption-context` is mentioned in the spec then do look into the input of the operation as the operation input will be specifying `encryption-context` which will clear up the context of `encryption-context`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Check any applicable:

- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.
