### PR TITLE
chore: adjust spec to avoid Duvet panic

### DIFF
--- a/s3-encryption/client.md
+++ b/s3-encryption/client.md
@@ -111,6 +111,8 @@ The inclusion of a source of randomness is subject to language availability.
 
 ## API Operations
 
+The S3EC provides various API operations.
+
 ### Required API Operations
 
 The S3EC must provide implementations for the following S3 operations:


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

There's some weird bug in Duvet where it was panicking after some changes to the previous PR. Adding some text between the section (sub)headers fixes it. Issue cut to Duvet: https://github.com/awslabs/duvet/issues/182

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Check any applicable:

- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.
