### PR TITLE
feat(shim): specify streaming, bulk data, errors, and adoption

### DIFF
--- a/shim/esdk-shim.md
+++ b/shim/esdk-shim.md
@@ -229,9 +229,8 @@ picking a precedence rule is not.
 - A successful finish step MUST return the same non-payload outputs as
   [encrypt outputs](#encrypt-outputs) or [decrypt outputs](#decrypt-outputs).
 - Streamed decrypt MUST NOT release plaintext the core ESDK would not release,
-  and the shim MUST surface, and MUST NOT work around, the core ESDK's refusal
-  to stream a message whose verification cannot complete until the end of the
-  message.
+  and the shim MUST surface the core ESDK's refusal to stream a message whose
+  verification cannot complete until the end of the message.
 
 ### Create KMS client
 

--- a/shim/esdk-shim.md
+++ b/shim/esdk-shim.md
@@ -156,8 +156,10 @@ The ESDK shim MAY expose a client-level configuration carrying a commitment
 policy and a maximum number of encrypted data keys, applied to every operation
 of that client.
 
-- A value the target supplies on a per-operation input MUST override the
-  client-level value for the same field for that operation.
+- Matching the core ESDK's client, a field the target sets on both the client
+  and a per-operation input MUST be rejected as invalid input: rejecting today
+  is forward-compatible with defining override semantics later, while picking
+  a precedence rule today is not.
 - A field the target sets on neither the client nor the operation MUST defer
   to the core ESDK's default.
 
@@ -224,9 +226,8 @@ of that client.
   accepting the same inputs as [encrypt](#encrypt-inputs) and
   [decrypt](#decrypt-inputs) except the plaintext or ciphertext, which the
   target supplies incrementally.
-- On successful completion, a streaming operation MUST return the same
-  non-payload outputs as [encrypt outputs](#encrypt-outputs) or
-  [decrypt outputs](#decrypt-outputs).
+- A successful finish step MUST return the same non-payload outputs as
+  [encrypt outputs](#encrypt-outputs) or [decrypt outputs](#decrypt-outputs).
 - Streamed decrypt MUST NOT release plaintext the core ESDK would not release,
   and the shim MUST surface, and MUST NOT work around, the core ESDK's refusal
   to stream a message whose verification cannot complete until the end of the

--- a/shim/esdk-shim.md
+++ b/shim/esdk-shim.md
@@ -155,12 +155,13 @@ per [Delegation](./shim.md#delegation).
 The ESDK shim MAY expose a client-level configuration mirroring the core
 ESDK's client configuration, applied to every operation of that client.
 
-- Matching the core ESDK's client, a configuration value the target supplies
-  on both the client and a per-operation input MUST be rejected as invalid
-  input: rejecting is forward-compatible with defining override semantics
-  later, while picking a precedence rule is not.
+- A configuration value the target supplies on both the client and a
+  per-operation input MUST be rejected as invalid input.
 - A configuration value the target supplies on neither the client nor the
   operation MUST defer to the core ESDK's default.
+
+Rejecting is forward-compatible with defining override semantics later;
+picking a precedence rule is not.
 
 ### Materials source
 

--- a/shim/esdk-shim.md
+++ b/shim/esdk-shim.md
@@ -150,6 +150,17 @@ where an input or output is passed through unmodified, each is translated per
 [Type translation](#type-translation), and each operation invokes the core ESDK
 per [Delegation](./shim.md#delegation).
 
+### Client configuration
+
+The ESDK shim MAY expose a client-level configuration carrying a commitment
+policy and a maximum number of encrypted data keys, applied to every operation
+of that client.
+
+- A value the target supplies on a per-operation input MUST override the
+  client-level value for the same field for that operation.
+- A field the target sets on neither the client nor the operation MUST defer
+  to the core ESDK's default.
+
 ### Materials source
 
 - Each of `encrypt` and `decrypt` MUST be supplied with exactly one materials
@@ -206,6 +217,20 @@ per [Delegation](./shim.md#delegation).
   [Algorithm suite identifier](#algorithm-suite-identifier).
 - MUST return the result encryption context, converted as defined in
   [Encryption context](#encryption-context).
+
+### Encrypt stream and decrypt stream
+
+- The ESDK shim SHOULD provide streaming encrypt and decrypt operations,
+  accepting the same inputs as [encrypt](#encrypt-inputs) and
+  [decrypt](#decrypt-inputs) except the plaintext or ciphertext, which the
+  target supplies incrementally.
+- On successful completion, a streaming operation MUST return the same
+  non-payload outputs as [encrypt outputs](#encrypt-outputs) or
+  [decrypt outputs](#decrypt-outputs).
+- Streamed decrypt MUST NOT release plaintext the core ESDK would not release,
+  and the shim MUST surface, and MUST NOT work around, the core ESDK's refusal
+  to stream a message whose verification cannot complete until the end of the
+  message.
 
 ### Create KMS client
 

--- a/shim/esdk-shim.md
+++ b/shim/esdk-shim.md
@@ -152,16 +152,15 @@ per [Delegation](./shim.md#delegation).
 
 ### Client configuration
 
-The ESDK shim MAY expose a client-level configuration carrying a commitment
-policy and a maximum number of encrypted data keys, applied to every operation
-of that client.
+The ESDK shim MAY expose a client-level configuration mirroring the core
+ESDK's client configuration, applied to every operation of that client.
 
-- Matching the core ESDK's client, a field the target sets on both the client
-  and a per-operation input MUST be rejected as invalid input: rejecting today
-  is forward-compatible with defining override semantics later, while picking
-  a precedence rule today is not.
-- A field the target sets on neither the client nor the operation MUST defer
-  to the core ESDK's default.
+- Matching the core ESDK's client, a configuration value the target supplies
+  on both the client and a per-operation input MUST be rejected as invalid
+  input: rejecting is forward-compatible with defining override semantics
+  later, while picking a precedence rule is not.
+- A configuration value the target supplies on neither the client nor the
+  operation MUST defer to the core ESDK's default.
 
 ### Materials source
 

--- a/shim/shim.md
+++ b/shim/shim.md
@@ -87,18 +87,21 @@ each value it exposes. Every such translation MUST obey the following rules.
 
 ### Bulk data
 
-Payload-sized byte inputs and outputs (for example a plaintext or ciphertext)
-can dominate an operation's cost if each boundary crossing copies them.
+A payload (a plaintext or a ciphertext) can be very large. If the shim copies
+the payload on the way in, and copies the result on the way out, every
+operation pays for two payload-sized copies and briefly holds two copies of
+the payload in memory. For a shim, whose purpose is a thin boundary, that cost
+is avoidable: the core library can read the caller's bytes where they already
+are, and the caller can read the result where the core library wrote it.
 
-- The shim SHOULD accept bulk byte input by reference to the target's buffer,
-  without copying it; the buffer need only remain valid for the duration of
-  the call.
-- The shim SHOULD expose bulk byte output to the target as a read-only view of
-  the core library's buffer, without copying it.
-- A view of a core-library buffer MUST keep that buffer alive until the target
-  releases the view.
-- The shim MUST provide a way to copy a view's bytes into a target-owned
-  buffer.
+- The shim SHOULD let the caller pass a payload without first copying it into
+  a shim-defined container: the operation reads the caller's bytes in place,
+  and the caller's bytes need to stay valid only for the duration of the call.
+- The shim SHOULD let the caller read a payload result in place, where the
+  core library wrote it, instead of copying it into a new container first.
+- A result exposed this way MUST remain valid until the caller releases it.
+- The shim MUST also let the caller copy a result into memory the caller
+  owns.
 
 ## Delegation
 
@@ -121,15 +124,18 @@ input validation, and is not subject to the rule above.
 
 ### Error classification
 
-- The shim SHOULD classify the errors it returns so that the target can
-  distinguish, at minimum: a failed cryptographic verification (retrying the
-  same input cannot succeed), a failed call to a dependency service (retrying
-  may succeed), and invalid target-supplied input.
-- A classified error MUST also be identifiable as the shim's own error type, so
-  a target that handles only the shim's error type is unaffected when a
-  classification is added.
-- An error the shim does not classify MUST be reported as the shim's own error
-  type.
+The core library's errors are the errors; the shim only carries them across
+the boundary.
+
+- When the core library distinguishes kinds of errors, the shim SHOULD expose
+  the same kinds under the core library's own names, expressed in the target
+  language's error mechanism.
+- The shim MUST NOT invent error kinds the core library does not define.
+- Every exposed error kind MUST also be identifiable as the shim's own base
+  error type, so a target that handles only the base type is unaffected when a
+  kind is added.
+- An error whose kind the shim does not expose MUST be reported as the shim's
+  own base error type.
 
 ## Resources
 
@@ -177,18 +183,20 @@ A core library can define interfaces that its consumer implements and that the
 core library invokes during an operation — for example, a custom keyring or a
 custom cryptographic materials manager.
 
-A consumer defines such an implementation in the core library's language, as
-any value the core library accepts for that interface; the shim adopts the
-result and hands the target a handle.
+The shim does not define these implementations, and does not need to
+understand them. A consumer writes one in the core library's language; the
+shim's job is only to turn it into an ordinary handle. This is called
+**adoption**.
 
-- The shim MAY provide a means for the target to adopt a consumer-defined
-  implementation of a core-library interface.
-- The adoption mechanism MUST accept any implementation the core library
-  accepts for that interface, without depending on which library defines it.
-- Adoption MUST transfer ownership of the adopted implementation; the shim
-  MUST accept each adoptable handle at most once.
-- A handle to an adopted implementation MUST be usable wherever that
-  interface's handle type is accepted.
+- The shim MAY let the target adopt a consumer-written implementation of a
+  core-library interface.
+- Anything the core library accepts for that interface MUST be adoptable. The
+  shim MUST NOT depend on where the implementation came from or which library
+  defined it.
+- An adopted handle MUST work everywhere a handle of that interface's type
+  works.
+- Adoption MUST take ownership: each adoptable value is adopted at most once,
+  and afterwards the handle is the only way to reach it.
 
 ### Concurrency
 
@@ -200,17 +208,22 @@ the shim library SHOULD support it as well.
 If a core library resource or operation supports [streamed](../client-apis/streaming.md) inputs/outputs,
 the shim library SHOULD support it as well.
 
-When the shim exposes a streamed operation:
+A streamed operation has three parts, and the shim MUST provide all three:
 
-- The shim MUST provide a mechanism for the target to supply input
-  incrementally, a mechanism for the target to consume output as it is
-  released, and an explicit completion step that ends the input and reports
-  the operation's result.
-- The shim SHOULD release output to the target as the core library produces
-  it, without waiting for the input to complete.
-- Output released before completion MUST NOT be treated as complete or
-  verified until the completion step succeeds, and the shim MUST NOT weaken
-  the core library's own rules for releasing unverified output.
+- a **write** step the target calls repeatedly, each call supplying the next
+  chunk of input and returning whatever output the operation has produced so
+  far (possibly none);
+- a **finish** step that ends the input, completes the operation, and returns
+  the operation's result together with any output not yet returned by a write;
+- an error from any step when the operation has failed.
+
+Additionally:
+
+- The shim SHOULD return output from write steps as the core library produces
+  it, rather than holding all output until the finish step.
+- Output returned before the finish step succeeds MUST NOT be treated as
+  complete or verified, and the shim MUST NOT weaken the core library's own
+  rules for releasing unverified output.
 
 ## Operation contracts
 

--- a/shim/shim.md
+++ b/shim/shim.md
@@ -183,8 +183,8 @@ A core library can define interfaces that its consumer implements and that the
 core library invokes during an operation — for example, a custom keyring or a
 custom cryptographic materials manager.
 
-The shim does not define these implementations, and does not need to
-understand them. A consumer writes one in the core library's language; the
+The shim does not define these implementations. A consumer writes one in the
+core library's language; the
 shim's job is only to turn it into an ordinary handle in the target language.
 This is called **adoption**.
 
@@ -227,10 +227,8 @@ When the shim exposes a streamed operation:
   it, rather than holding all output until the finish step.
 - The shim MUST NOT weaken the core library's own rules for releasing
   unverified output.
-
-Output returned before the finish step succeeds is not yet complete or
-verified; the shim documents this for the target where the output is
-returned.
+- The shim MUST document to users that output returned before the finish step
+  succeeds is not yet complete or verified.
 
 ## Operation contracts
 

--- a/shim/shim.md
+++ b/shim/shim.md
@@ -185,18 +185,27 @@ custom cryptographic materials manager.
 
 The shim does not define these implementations, and does not need to
 understand them. A consumer writes one in the core library's language; the
-shim's job is only to turn it into an ordinary handle. This is called
-**adoption**.
+shim's job is only to turn it into an ordinary handle in the target language.
+This is called **adoption**.
 
 - The shim MAY let the target adopt a consumer-written implementation of a
   core-library interface.
-- Anything the core library accepts for that interface MUST be adoptable. The
-  shim MUST NOT depend on where the implementation came from or which library
-  defined it.
+- Anything the core library accepts for that interface MUST be adoptable.
+- The shim MUST NOT depend on which library defined an adopted implementation.
 - An adopted handle MUST work everywhere a handle of that interface's type
   works.
 - Adoption MUST take ownership: each adoptable value is adopted at most once,
   and afterwards the handle is the only way to reach it.
+
+Adoption converts; it does not construct or validate. A value presented for
+adoption already conforms to its interface, and any failure to construct one
+is reported in the core library's language before adoption is reached —
+neither is the shim's to check or report.
+
+- Errors an adopted implementation returns during an operation MUST be
+  reported like any core-library error (see [Delegation](#delegation)).
+- The target MUST adopt only values produced by the shim's conversion, and
+  MUST adopt each at most once; the shim does not detect violations.
 
 ### Concurrency
 
@@ -208,22 +217,22 @@ the shim library SHOULD support it as well.
 If a core library resource or operation supports [streamed](../client-apis/streaming.md) inputs/outputs,
 the shim library SHOULD support it as well.
 
-A streamed operation has three parts, and the shim MUST provide all three:
+When the shim exposes a streamed operation:
 
-- a **write** step the target calls repeatedly, each call supplying the next
-  chunk of input and returning whatever output the operation has produced so
-  far (possibly none);
-- a **finish** step that ends the input, completes the operation, and returns
-  the operation's result together with any output not yet returned by a write;
-- an error from any step when the operation has failed.
-
-Additionally:
-
+- The shim MUST provide a write step that the target calls repeatedly, each
+  call supplying the next chunk of input and returning whatever output the
+  operation has produced so far (possibly none).
+- The shim MUST provide a finish step that ends the input, completes the
+  operation, and returns the operation's result together with any output not
+  yet returned by a write step.
+- When the operation has failed, the shim MUST return an error from the next
+  write or finish step.
 - The shim SHOULD return output from write steps as the core library produces
   it, rather than holding all output until the finish step.
 - Output returned before the finish step succeeds MUST NOT be treated as
-  complete or verified, and the shim MUST NOT weaken the core library's own
-  rules for releasing unverified output.
+  complete or verified.
+- The shim MUST NOT weaken the core library's own rules for releasing
+  unverified output.
 
 ## Operation contracts
 

--- a/shim/shim.md
+++ b/shim/shim.md
@@ -191,16 +191,12 @@ This is called **adoption**.
 - The shim MAY let the target adopt a consumer-written implementation of a
   core-library interface.
 - Anything the core library accepts for that interface MUST be adoptable.
-- The shim MUST NOT depend on which library defined an adopted implementation.
-- An adopted handle MUST work everywhere a handle of that interface's type
-  works.
-- Adoption MUST take ownership: each adoptable value is adopted at most once,
-  and afterwards the handle is the only way to reach it.
 
-Adoption converts; it does not construct or validate. A value presented for
-adoption already conforms to its interface, and any failure to construct one
-is reported in the core library's language before adoption is reached —
-neither is the shim's to check or report.
+Adoption does not construct or validate. A value presented for adoption is
+assumed to already conform to its interface: conformance is the consumer's to
+ensure when writing the implementation, and any failure to construct the value
+is reported in the core library's language before adoption is reached. The
+shim relies on that assumption and does not check it.
 
 - Errors an adopted implementation returns during an operation MUST be
   reported like any core-library error (see [Delegation](#delegation)).
@@ -229,10 +225,12 @@ When the shim exposes a streamed operation:
   write or finish step.
 - The shim SHOULD return output from write steps as the core library produces
   it, rather than holding all output until the finish step.
-- Output returned before the finish step succeeds MUST NOT be treated as
-  complete or verified.
 - The shim MUST NOT weaken the core library's own rules for releasing
   unverified output.
+
+Output returned before the finish step succeeds is not yet complete or
+verified; the shim documents this for the target where the output is
+returned.
 
 ## Operation contracts
 

--- a/shim/shim.md
+++ b/shim/shim.md
@@ -85,6 +85,21 @@ each value it exposes. Every such translation MUST obey the following rules.
 - When the core library produces a value the shim does not define, the
   translation MUST return an error.
 
+### Bulk data
+
+Payload-sized byte inputs and outputs (for example a plaintext or ciphertext)
+can dominate an operation's cost if each boundary crossing copies them.
+
+- The shim SHOULD accept bulk byte input by reference to the target's buffer,
+  without copying it; the buffer need only remain valid for the duration of
+  the call.
+- The shim SHOULD expose bulk byte output to the target as a read-only view of
+  the core library's buffer, without copying it.
+- A view of a core-library buffer MUST keep that buffer alive until the target
+  releases the view.
+- The shim MUST provide a way to copy a view's bytes into a target-owned
+  buffer.
+
 ## Delegation
 
 The shim implements none of the core library's behavior of its own; it forwards
@@ -103,6 +118,18 @@ enforce validity. These requirements pin down that forwarding.
 Checking a target-supplied handle for presence before dereferencing it (see
 [Handles and lifetimes](#handles-and-lifetimes)) is a memory-safety measure, not
 input validation, and is not subject to the rule above.
+
+### Error classification
+
+- The shim SHOULD classify the errors it returns so that the target can
+  distinguish, at minimum: a failed cryptographic verification (retrying the
+  same input cannot succeed), a failed call to a dependency service (retrying
+  may succeed), and invalid target-supplied input.
+- A classified error MUST also be identifiable as the shim's own error type, so
+  a target that handles only the shim's error type is unaffected when a
+  classification is added.
+- An error the shim does not classify MUST be reported as the shim's own error
+  type.
 
 ## Resources
 
@@ -150,8 +177,18 @@ A core library can define interfaces that its consumer implements and that the
 core library invokes during an operation — for example, a custom keyring or a
 custom cryptographic materials manager.
 
-How a shim exposes such custom implementations is not yet specified; a future
-revision of this specification will define it.
+A consumer defines such an implementation in the core library's language, as
+any value the core library accepts for that interface; the shim adopts the
+result and hands the target a handle.
+
+- The shim MAY provide a means for the target to adopt a consumer-defined
+  implementation of a core-library interface.
+- The adoption mechanism MUST accept any implementation the core library
+  accepts for that interface, without depending on which library defines it.
+- Adoption MUST transfer ownership of the adopted implementation; the shim
+  MUST accept each adoptable handle at most once.
+- A handle to an adopted implementation MUST be usable wherever that
+  interface's handle type is accepted.
 
 ### Concurrency
 
@@ -162,6 +199,18 @@ the shim library SHOULD support it as well.
 
 If a core library resource or operation supports [streamed](../client-apis/streaming.md) inputs/outputs,
 the shim library SHOULD support it as well.
+
+When the shim exposes a streamed operation:
+
+- The shim MUST provide a mechanism for the target to supply input
+  incrementally, a mechanism for the target to consume output as it is
+  released, and an explicit completion step that ends the input and reports
+  the operation's result.
+- The shim SHOULD release output to the target as the core library produces
+  it, without waiting for the input to complete.
+- Output released before completion MUST NOT be treated as complete or
+  verified until the completion step succeeds, and the shim MUST NOT weaken
+  the core library's own rules for releasing unverified output.
 
 ## Operation contracts
 


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

Specify shim behavior proven out in the aws-esdk-cpp shim: streamed operations (incremental input/output, explicit completion, unverified-output rules), bulk byte passing without boundary copies, error classification, adoption of consumer-defined implementations of core-library interfaces, and ESDK client-level configuration with per-operation override.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Check any applicable:

- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.
